### PR TITLE
Optimize Sass imports

### DIFF
--- a/www/sass/_code.scss
+++ b/www/sass/_code.scss
@@ -1,4 +1,4 @@
-@import "./variables";
+@use "./variables" as v;
 
 $contentClass: ".theme-container";
 
@@ -26,7 +26,7 @@ $codeLang: (
 
 #{$contentClass} {
   code {
-    color: lighten($colorText, 20%);
+    color: lighten(v.$colorText, 20%);
     padding: 0.25rem 0.5rem;
     margin: 0;
     background-color: rgba(27, 31, 35, 0.05);
@@ -38,7 +38,7 @@ $codeLang: (
       }
 
       &.inserted {
-        color: $colorAccent;
+        color: v.$colorAccent;
       }
     }
   }
@@ -49,8 +49,8 @@ $codeLang: (
   pre[class*="language-"] {
     line-height: 1.4;
     padding: 1.25rem 1.5rem;
-    margin: 4 * $space-unit 0 !important;
-    background-color: $colorCodeBackground;
+    margin: 4 * v.$space-unit 0 !important;
+    background-color: v.$colorCodeBackground;
     border-radius: 6px;
     overflow: auto;
 
@@ -65,7 +65,7 @@ $codeLang: (
 
 div[class*="language-"] {
   position: relative;
-  background-color: $colorCodeBackground;
+  background-color: v.$colorCodeBackground;
   border-radius: 6px;
 
   .highlight-lines {
@@ -115,21 +115,21 @@ div[class*="language-"] {
         left: 0;
         top: 0;
         display: block;
-        width: $lineNumbersWrapperWidth;
+        width: v.$lineNumbersWrapperWidth;
         height: 100%;
         background-color: rgba(0, 0, 0, 66%);
       }
     }
 
     pre {
-      padding-left: $lineNumbersWrapperWidth + 1em;
+      padding-left: v.$lineNumbersWrapperWidth + 1em;
       vertical-align: middle;
     }
 
     .line-numbers-wrapper {
       position: absolute;
       top: 0;
-      width: $lineNumbersWrapperWidth;
+      width: v.$lineNumbersWrapperWidth;
       text-align: center;
       color: rgba(255, 255, 255, 0.3);
       padding: 1.25rem 0;
@@ -153,11 +153,11 @@ div[class*="language-"] {
       z-index: 2;
       top: 0;
       left: 0;
-      width: $lineNumbersWrapperWidth;
+      width: v.$lineNumbersWrapperWidth;
       height: 100%;
       border-radius: 6px 0 0 6px;
       border-right: 1px solid rgba(0, 0, 0, 66%);
-      background-color: $colorCodeBackground;
+      background-color: v.$colorCodeBackground;
     }
   }
 }

--- a/www/sass/_components.scss
+++ b/www/sass/_components.scss
@@ -1,5 +1,5 @@
-@import "./variables";
-@import "./mixins";
+@use "./variables" as v;
+@use "./mixins";
 
 .p-btn {
   background: none;
@@ -10,11 +10,11 @@
   align-items: center;
   font-size: 100%;
   font-family: inherit;
-  padding-left: 3 * $space-unit;
-  padding-right: 3 * $space-unit;
+  padding-left: 3 * v.$space-unit;
+  padding-right: 3 * v.$space-unit;
   border-radius: 3px;
-  height: 7 * $space-unit;
-  line-height: 3.5 * $space-unit;
+  height: 7 * v.$space-unit;
+  line-height: 3.5 * v.$space-unit;
 
   &:hover {
     cursor: pointer;
@@ -22,44 +22,44 @@
 }
 
 .p-btn--primary {
-  background: $colorPrimary;
+  background: v.$colorPrimary;
   box-shadow: 0px 1px 3px 0px transparentize(black, 0.3);
 
   &:hover {
-    background: darken($colorPrimary, 10%);
+    background: darken(v.$colorPrimary, 10%);
   }
 
   &:focus {
-    background: darken($colorPrimary, 20%);
+    background: darken(v.$colorPrimary, 20%);
   }
 }
 
 .p-btn--warn {
-  background: $colorWarn;
+  background: v.$colorWarn;
 
   &:hover {
-    background: darken($colorWarn, 10%);
+    background: darken(v.$colorWarn, 10%);
   }
 
   &:focus {
-    background: darken($colorWarn, 20%);
+    background: darken(v.$colorWarn, 20%);
   }
 }
 
 .p-btn--icon {
   :first-child {
-    margin-right: $space-unit;
+    margin-right: v.$space-unit;
   }
 }
 
 .p-card {
-  background-color: $colorBackgroundCard;
+  background-color: v.$colorBackgroundCard;
   padding: 1em 2em;
   border-radius: 3px;
 }
 
 .p-image {
-  @include u-mv(4);
+  @include mixins.u-mv(4);
 
   img {
     display: block;
@@ -68,11 +68,11 @@
   }
 
   figcaption {
-    @include u-pt(2);
+    @include mixins.u-pt(2);
     text-align: center;
-    color: $colorMuted;
+    color: v.$colorMuted;
     font-style: italic;
-    font-size: $font-size-caption;
+    font-size: v.$font-size-caption;
   }
 }
 

--- a/www/sass/_util.scss
+++ b/www/sass/_util.scss
@@ -1,8 +1,9 @@
-@import "./mixins";
+@use "./variables" as v;
+@use "./mixins";
 
 @mixin spacing-utils($n) {
   .u-m-#{$n} {
-    @include u-m($n);
+    @include mixins.u-m($n);
   }
 
   // Uncomment if used.
@@ -11,11 +12,11 @@
   // }
 
   .u-ph-#{$n} {
-    @include u-ph($n);
+    @include mixins.u-ph($n);
   }
 
   .u-mh-#{$n} {
-    @include u-mh($n);
+    @include mixins.u-mh($n);
   }
 
   // Uncomment if used.
@@ -49,19 +50,19 @@
   // }
 
   .u-pt-#{$n} {
-    @include u-pt($n);
+    @include mixins.u-pt($n);
   }
 
   .u-mt-#{$n} {
-    @include u-mt($n);
+    @include mixins.u-mt($n);
   }
 
   .u-pb-#{$n} {
-    @include u-pb($n);
+    @include mixins.u-pb($n);
   }
 
   .u-mb-#{$n} {
-    @include u-mb($n);
+    @include mixins.u-mb($n);
   }
 
   // Uncomment if used.
@@ -75,21 +76,21 @@
 }
 
 .u-max-w-128 {
-  @include u-max-w(128);
+  @include mixins.u-max-w(128);
 }
 
 @include spacing-utils(auto);
 
 .u-w-full {
-  @include u-w(100%);
+  @include mixins.u-w(100%);
 }
 
 .u-color-primary {
-  color: $colorPrimary;
+  color: v.$colorPrimary;
 }
 
 .u-color-muted {
-  color: $colorMuted;
+  color: v.$colorMuted;
 }
 
 .u-flex-centerHorizontal {

--- a/www/sass/app/_index.scss
+++ b/www/sass/app/_index.scss
@@ -1,2 +1,2 @@
-@import "./components/";
-@import "./layouts";
+@forward "./components/";
+@forward "./layouts";

--- a/www/sass/app/components/_index.scss
+++ b/www/sass/app/components/_index.scss
@@ -1,3 +1,3 @@
-@import "./article_tag_list";
-@import "./list_item";
-@import "./navbar";
+@forward "./article_tag_list";
+@forward "./list_item";
+@forward "./navbar";

--- a/www/sass/app/components/_list_item.scss
+++ b/www/sass/app/components/_list_item.scss
@@ -1,19 +1,19 @@
-@import "../../variables";
-@import "../../mixins";
+@use "../../variables" as v;
+@use "../../mixins";
 
 .c_list_item-item {
   padding-bottom: 1em;
 
   & + .c_list_item-item {
     padding-top: 1em;
-    border-top: 1px solid $colorDivider;
+    border-top: 1px solid v.$colorDivider;
   }
 }
 
 .c_list_item-post-header {
   font-size: smaller;
 
-  @include forSize(tablet) {
+  @include mixins.forSize(tablet) {
     font-size: inherit;
   }
 }

--- a/www/sass/app/components/_navbar.scss
+++ b/www/sass/app/components/_navbar.scss
@@ -1,13 +1,13 @@
-@import "../../variables";
+@use "../../variables" as v;
 
 .c_navbar-nav {
-  background-color: $colorBackgroundCard;
+  background-color: v.$colorBackgroundCard;
   z-index: 100; // Float on top of page content.
 
   ul {
     display: grid;
     grid-template-columns: auto 1fr;
-    grid-gap: 6 * $space-unit;
+    grid-gap: 6 * v.$space-unit;
     align-items: center;
 
     li {
@@ -18,6 +18,6 @@
 }
 
 .c_navbar-title {
-  font-size: $font-size-title;
+  font-size: v.$font-size-title;
   width: fit-content;
 }

--- a/www/sass/app/layouts/_article_detail.scss
+++ b/www/sass/app/layouts/_article_detail.scss
@@ -1,9 +1,9 @@
-@import "../../variables";
-@import "../../mixins";
+@use "../../variables" as v;
+@use "../../mixins";
 
 .c_article_detail-header {
-  margin-bottom: 6 * $space-unit;
-  border-bottom: 1px solid $colorDivider;
+  margin-bottom: 6 * v.$space-unit;
+  border-bottom: 1px solid v.$colorDivider;
 }
 
 .c_article_detail-tag-list {
@@ -18,8 +18,8 @@
   & h4,
   & h5,
   & h6 {
-    margin-top: 8 * $space-unit;
-    margin-bottom: 5 * $space-unit;
+    margin-top: 8 * v.$space-unit;
+    margin-bottom: 5 * v.$space-unit;
   }
 
   img {

--- a/www/sass/app/layouts/_index.scss
+++ b/www/sass/app/layouts/_index.scss
@@ -1,2 +1,2 @@
-@import "./article_detail";
-@import "./layout";
+@forward "./article_detail";
+@forward "./layout";

--- a/www/sass/app/layouts/_layout.scss
+++ b/www/sass/app/layouts/_layout.scss
@@ -1,10 +1,10 @@
-@import "../../variables";
-@import "../../mixins";
+@use "../../variables" as v;
+@use "../../mixins";
 
 .c_layout-content {
-  padding: 0 4 * $space-unit;
+  padding: 0 4 * v.$space-unit;
 
-  @include forSize("tablet") {
-    padding: 0 8 * $space-unit;
+  @include mixins.forSize("tablet") {
+    padding: 0 8 * v.$space-unit;
   }
 }

--- a/www/sass/mixins/_index.scss
+++ b/www/sass/mixins/_index.scss
@@ -1,2 +1,2 @@
-@import "./_responsive";
-@import "./_util";
+@forward "./_responsive";
+@forward "./_util";

--- a/www/sass/mixins/_responsive.scss
+++ b/www/sass/mixins/_responsive.scss
@@ -1,8 +1,8 @@
-@import "../variables";
+@use "../variables" as v;
 
 @mixin forSize($breakName: "phone", $breakValue: 0, $mobileFirst: true) {
   @if $breakName != "phone" {
-    $breakValue: map-get($breakpoints, $breakName);
+    $breakValue: map-get(v.$breakpoints, $breakName);
   }
 
   @if ($mobileFirst) {

--- a/www/sass/mixins/_util.scss
+++ b/www/sass/mixins/_util.scss
@@ -1,10 +1,10 @@
-@import "../variables";
+@use "../variables" as v;
 
 @function normalize($val) {
   @if $val == auto or $val == 100% {
     @return $val;
   }
-  @return $val * $space-unit;
+  @return $val * v.$space-unit;
 }
 
 // Margins

--- a/www/sass/styles.scss
+++ b/www/sass/styles.scss
@@ -1,4 +1,10 @@
-@import "./variables";
+@use "./variables" as v;
+@use "./components";
+@use "./util";
+@use "./code";
+@use "./tables";
+@use "./pygments_theme";
+@use "./app";
 
 @font-face {
   font-family: "EB Garamond";
@@ -35,11 +41,11 @@ body {
 }
 
 body {
-  color: $colorText;
+  color: v.$colorText;
   font-family: "EB Garamond", Helvetica, Arial, sans-serif;
   font-weight: normal;
-  font-size: $font-size;
-  line-height: $font-line-height;
+  font-size: v.$font-size;
+  line-height: v.$font-line-height;
 }
 
 h1,
@@ -49,36 +55,36 @@ h4,
 h5,
 h6 {
   font-weight: 500;
-  margin-top: 1 * $space-unit;
-  margin-bottom: 3 * $space-unit;
+  margin-top: 1 * v.$space-unit;
+  margin-bottom: 3 * v.$space-unit;
 }
 
 h1 {
-  font-size: $font-size-h1;
+  font-size: v.$font-size-h1;
 }
 
 h2 {
-  font-size: $font-size-h2;
+  font-size: v.$font-size-h2;
 }
 
 h3 {
-  font-size: $font-size-h3;
+  font-size: v.$font-size-h3;
 }
 
 p {
   margin-top: 0;
-  margin-bottom: 2 * $space-unit;
+  margin-bottom: 2 * v.$space-unit;
 }
 
 a {
   text-decoration: none;
-  border-bottom: 1px solid $colorPrimary;
+  border-bottom: 1px solid v.$colorPrimary;
   transition: background 80ms;
   cursor: pointer;
   color: inherit;
 
   &:hover {
-    background-color: transparentize($colorPrimary, 0.8);
+    background-color: transparentize(v.$colorPrimary, 0.8);
   }
 }
 
@@ -87,7 +93,7 @@ hr {
   padding: 0;
   border: 0;
   height: 1px;
-  background-color: $colorDivider;
+  background-color: v.$colorDivider;
 }
 
 // Icons in front of subheaders.
@@ -106,10 +112,3 @@ h3[id] {
     margin-top: 0.125em;
   }
 }
-
-@import "./components";
-@import "./util";
-@import "./code";
-@import "./tables";
-@import "./pygments_theme";
-@import "./app";

--- a/www/sass/variables/_index.scss
+++ b/www/sass/variables/_index.scss
@@ -1,3 +1,3 @@
-@import "./_palette";
-@import "./_typography";
-@import "./_responsive";
+@forward "./_palette";
+@forward "./_typography";
+@forward "./_responsive";

--- a/www/static/css/styles.css
+++ b/www/static/css/styles.css
@@ -1,178 +1,4 @@
 @charset "UTF-8";
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/regular.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: italic;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/italic.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: 500;
-  src: url("/static/fonts/eb-garamond/medium.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: bold;
-  src: url("/static/fonts/eb-garamond/bold.ttf");
-}
-html,
-body {
-  padding: 0;
-  margin: 0;
-}
-
-body {
-  color: #424242;
-  font-family: "EB Garamond", Helvetica, Arial, sans-serif;
-  font-weight: normal;
-  font-size: 1.2em;
-  line-height: 1.5;
-}
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-weight: 500;
-  margin-top: 6px;
-  margin-bottom: 18px;
-}
-
-h1 {
-  font-size: 2.2em;
-}
-
-h2 {
-  font-size: 1.6em;
-}
-
-h3 {
-  font-size: 1.5em;
-}
-
-p {
-  margin-top: 0;
-  margin-bottom: 12px;
-}
-
-a {
-  text-decoration: none;
-  border-bottom: 1px solid #59c6b6;
-  transition: background 80ms;
-  cursor: pointer;
-  color: inherit;
-}
-a:hover {
-  background-color: rgba(89, 198, 182, 0.2);
-}
-
-hr {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  height: 1px;
-  background-color: #bccecc;
-}
-
-h1[id],
-h2[id],
-h3[id] {
-  position: relative;
-}
-h1[id] .header-anchor,
-h2[id] .header-anchor,
-h3[id] .header-anchor {
-  float: left;
-  font-weight: normal;
-  font-size: 0.85em;
-  margin-left: -0.87em;
-  padding-right: 0.23em;
-  padding-left: 0.23em;
-  margin-top: 0.125em;
-}
-
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/regular.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: italic;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/italic.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: 500;
-  src: url("/static/fonts/eb-garamond/medium.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: bold;
-  src: url("/static/fonts/eb-garamond/bold.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/regular.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: italic;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/italic.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: 500;
-  src: url("/static/fonts/eb-garamond/medium.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: bold;
-  src: url("/static/fonts/eb-garamond/bold.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/regular.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: italic;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/italic.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: 500;
-  src: url("/static/fonts/eb-garamond/medium.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: bold;
-  src: url("/static/fonts/eb-garamond/bold.ttf");
-}
 .p-btn {
   background: none;
   border: 0;
@@ -244,54 +70,6 @@ h3[id] .header-anchor {
   max-height: 20em;
 }
 
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/regular.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: italic;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/italic.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: 500;
-  src: url("/static/fonts/eb-garamond/medium.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: bold;
-  src: url("/static/fonts/eb-garamond/bold.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/regular.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: italic;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/italic.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: 500;
-  src: url("/static/fonts/eb-garamond/medium.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: bold;
-  src: url("/static/fonts/eb-garamond/bold.ttf");
-}
 .u-m-0 {
   margin-left: 0px;
   margin-right: 0px;
@@ -742,30 +520,6 @@ h3[id] .header-anchor {
   overflow-x: hidden;
 }
 
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/regular.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: italic;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/italic.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: 500;
-  src: url("/static/fonts/eb-garamond/medium.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: bold;
-  src: url("/static/fonts/eb-garamond/bold.ttf");
-}
 .theme-container code {
   color: #757575;
   padding: 0.25rem 0.5rem;
@@ -1378,78 +1132,6 @@ th, td {
   flex-wrap: wrap;
 }
 
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/regular.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: italic;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/italic.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: 500;
-  src: url("/static/fonts/eb-garamond/medium.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: bold;
-  src: url("/static/fonts/eb-garamond/bold.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/regular.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: italic;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/italic.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: 500;
-  src: url("/static/fonts/eb-garamond/medium.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: bold;
-  src: url("/static/fonts/eb-garamond/bold.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/regular.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: italic;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/italic.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: 500;
-  src: url("/static/fonts/eb-garamond/medium.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: bold;
-  src: url("/static/fonts/eb-garamond/bold.ttf");
-}
 .c_list_item-item {
   padding-bottom: 1em;
 }
@@ -1471,30 +1153,6 @@ th, td {
   content: "∙";
 }
 
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/regular.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: italic;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/italic.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: 500;
-  src: url("/static/fonts/eb-garamond/medium.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: bold;
-  src: url("/static/fonts/eb-garamond/bold.ttf");
-}
 .c_navbar-nav {
   background-color: #f2f4f5;
   z-index: 100;
@@ -1515,78 +1173,6 @@ th, td {
   width: fit-content;
 }
 
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/regular.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: italic;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/italic.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: 500;
-  src: url("/static/fonts/eb-garamond/medium.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: bold;
-  src: url("/static/fonts/eb-garamond/bold.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/regular.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: italic;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/italic.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: 500;
-  src: url("/static/fonts/eb-garamond/medium.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: bold;
-  src: url("/static/fonts/eb-garamond/bold.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/regular.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: italic;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/italic.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: 500;
-  src: url("/static/fonts/eb-garamond/medium.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: bold;
-  src: url("/static/fonts/eb-garamond/bold.ttf");
-}
 .c_article_detail-header {
   margin-bottom: 36px;
   border-bottom: 1px solid #bccecc;
@@ -1605,78 +1191,6 @@ th, td {
   height: auto;
 }
 
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/regular.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: italic;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/italic.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: 500;
-  src: url("/static/fonts/eb-garamond/medium.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: bold;
-  src: url("/static/fonts/eb-garamond/bold.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/regular.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: italic;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/italic.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: 500;
-  src: url("/static/fonts/eb-garamond/medium.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: bold;
-  src: url("/static/fonts/eb-garamond/bold.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/regular.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: italic;
-  font-weight: normal;
-  src: url("/static/fonts/eb-garamond/italic.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: 500;
-  src: url("/static/fonts/eb-garamond/medium.ttf");
-}
-@font-face {
-  font-family: "EB Garamond";
-  font-style: normal;
-  font-weight: bold;
-  src: url("/static/fonts/eb-garamond/bold.ttf");
-}
 .c_layout-content {
   padding: 0 24px;
 }
@@ -1684,6 +1198,108 @@ th, td {
   .c_layout-content {
     padding: 0 48px;
   }
+}
+
+@font-face {
+  font-family: "EB Garamond";
+  font-style: normal;
+  font-weight: normal;
+  src: url("/static/fonts/eb-garamond/regular.ttf");
+}
+@font-face {
+  font-family: "EB Garamond";
+  font-style: italic;
+  font-weight: normal;
+  src: url("/static/fonts/eb-garamond/italic.ttf");
+}
+@font-face {
+  font-family: "EB Garamond";
+  font-style: normal;
+  font-weight: 500;
+  src: url("/static/fonts/eb-garamond/medium.ttf");
+}
+@font-face {
+  font-family: "EB Garamond";
+  font-style: normal;
+  font-weight: bold;
+  src: url("/static/fonts/eb-garamond/bold.ttf");
+}
+html,
+body {
+  padding: 0;
+  margin: 0;
+}
+
+body {
+  color: #424242;
+  font-family: "EB Garamond", Helvetica, Arial, sans-serif;
+  font-weight: normal;
+  font-size: 1.2em;
+  line-height: 1.5;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: 500;
+  margin-top: 6px;
+  margin-bottom: 18px;
+}
+
+h1 {
+  font-size: 2.2em;
+}
+
+h2 {
+  font-size: 1.6em;
+}
+
+h3 {
+  font-size: 1.5em;
+}
+
+p {
+  margin-top: 0;
+  margin-bottom: 12px;
+}
+
+a {
+  text-decoration: none;
+  border-bottom: 1px solid #59c6b6;
+  transition: background 80ms;
+  cursor: pointer;
+  color: inherit;
+}
+a:hover {
+  background-color: rgba(89, 198, 182, 0.2);
+}
+
+hr {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  height: 1px;
+  background-color: #bccecc;
+}
+
+h1[id],
+h2[id],
+h3[id] {
+  position: relative;
+}
+h1[id] .header-anchor,
+h2[id] .header-anchor,
+h3[id] .header-anchor {
+  float: left;
+  font-weight: normal;
+  font-size: 0.85em;
+  margin-left: -0.87em;
+  padding-right: 0.23em;
+  padding-left: 0.23em;
+  margin-top: 0.125em;
 }
 
 /*# sourceMappingURL=styles.css.map */


### PR DESCRIPTION
`styles.css` contained many duplicated rules. This PR switches to [`@use`](https://sass-lang.com/documentation/at-rules/use) instead of `@import`.