### PR TITLE
Fix incorrect code in last example

### DIFF
--- a/content/articles/2018/10/reconciling-dataclasses-and-properties-in-python.md
+++ b/content/articles/2018/10/reconciling-dataclasses-and-properties-in-python.md
@@ -407,7 +407,7 @@ And the dataclass version, using a diff syntax to highlight the differences:
   class Vehicle:
 
 +     wheels: int
-+     _wheels: field(init=False, repr=False)
++     _wheels: int = field(init=False, repr=False)
 
 -     def __init__(self, wheels: int):
 -         self._wheels = wheels


### PR DESCRIPTION
The last example should actually use `dataclasses.field()` in the assignment, instead of the type annotation. Other examples in the article do the correct thing, so I assume this was an oversight. Although it's pretty obvious how `field()` should be used, fixing it would be great.

 Also, 👏 for this great article and the effort behind it.