### PR TITLE
Prevent fallback to legacy 'setup.py install' for wheels

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -28,6 +28,10 @@ else
   export PREFIX=""
 fi
 
+# Prevent falling back to legacy 'setup.py install' for wheels.
+note "Upgrade package 'wheel'"
+${PREFIX}pip install -U wheel
+
 note "Install pip dependencies"
 ${PREFIX}pip install -r requirements.txt
 


### PR DESCRIPTION
**Motivation**

This happens on CI:

```
Using legacy 'setup.py install' for autoflake, since package 'wheel' is not installed.
Using legacy 'setup.py install' for PyYAML, since package 'wheel' is not installed.
Installing collected packages: aiofiles, starlette, watchgod, arel, asgi-sitemaps, gunicorn, MarkupSafe, jinja2, markdown, pygments, PyYAML, six, python-frontmatter, h11, click, uvicorn, pyflakes, autoflake, sniffio, asgi-lifespan, mypy-extensions, regex, appdirs, typing-extensions, toml, typed-ast, pathspec, black, exdown, pycodestyle, mccabe, flake8, attrs, flake8-bugbear, flake8-comprehensions, flake8-pie, httpcore, idna, rfc3986, certifi, httpx, isort, mypy, pluggy, pyparsing, packaging, iniconfig, py, pytest, pytest-asyncio, coverage, pytest-cov, cached-property, aspy.refactor-imports, seed-isort-config
    Running setup.py install for PyYAML: started
    Running setup.py install for PyYAML: finished with status 'done'
    Running setup.py install for autoflake: started
    Running setup.py install for autoflake: finished with status 'done'
```

**Notes**
Follow-ups:
* Enable `--use-feature="2020-resolver"` because we're getting an `ERROR` on install.