### PR TITLE
Install dependencies using pip resolver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+--use-feature="2020-resolver"
+
 # Application dependencies.
 aiofiles==0.5.0
 arel==0.2.0


### PR DESCRIPTION
**Motivation**

https://dev.azure.com/florimondmanca/public/_build/results?buildId=860&view=logs&j=10b28c3e-f5e6-5a94-3fa6-e3c41d4e54d6&t=a1527d81-4978-57b2-0bb2-aef732900d3d&l=133

```
ERROR: After October 2020 you may experience errors when installing or updating packages. This is because pip will change the way that it resolves dependency conflicts.

We recommend you use --use-feature=2020-resolver to test your packages with the new resolver before it becomes the default.

httpcore 0.11.1 requires h11<0.10,>=0.8, but you'll have h11 0.11.0 which is incompatible.
```