### PR TITLE
Do not use pip resolver on prod

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
---use-feature="2020-resolver"
-
 # Application dependencies.
 aiofiles==0.5.0
 arel==0.2.0

--- a/scripts/install
+++ b/scripts/install
@@ -33,7 +33,7 @@ note "Upgrade package 'wheel'"
 ${PREFIX}pip install -U wheel
 
 note "Install pip dependencies"
-${PREFIX}pip install -r requirements.txt
+${PREFIX}pip install --use-feature="2020-resolver" -r requirements.txt
 
 if [ -z $CI ]; then
   note "Install yarn dependencies"


### PR DESCRIPTION
Cleanup for #140 

`heroku-buildpack-python` hardcodes the pip version to 20.1.1: https://github.com/heroku/heroku-buildpack-python/blob/main/bin/steps/python#L145

And I haven't found a way to override it.

So in the meantime, let's only apply `--use-feature="2020-resolver"` in `scripts/install`, outside of `requirements.txt`.