### PR TITLE
Use Python 3.9

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
 https://github.com/heroku/heroku-buildpack-nodejs.git#v172
-https://github.com/heroku/heroku-buildpack-python.git#v165
+https://github.com/heroku/heroku-buildpack-python.git#v184

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Code for https://florimond.dev.
 
 Runtime:
 
-- Python 3.8+
+- Python 3.9+
 
 Development only:
 

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -4,7 +4,7 @@ resources:
       type: github
       endpoint: github
       name: florimondmanca/azure-pipelines-templates
-      ref: refs/tags/3.2
+      ref: refs/tags/3.3
 
 trigger:
   - master
@@ -21,7 +21,7 @@ variables:
 jobs:
   - template: job--python-check.yml@templates
     parameters:
-      pythonVersion: "3.8"
+      pythonVersion: "3.9"
 
   - job: Build
     steps:
@@ -34,14 +34,14 @@ jobs:
   - template: job--python-test.yml@templates
     parameters:
       jobs:
-        py38:
+        py39:
           coverage: true
 
   - job: Deploy
     dependsOn:
       - Check
       - Build
-      - py38
+      - py39
     condition: and(succeeded(), eq(variables.IS_MASTER_BRANCH, true))
     steps:
       - task: InstallSSHKey@0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ markdown==3.2.2
 pygments==2.7.1
 python-frontmatter==0.5.0
 starlette==0.13.8
-uvicorn==0.12.2
+uvicorn[standard]==0.12.2
 
 # Development, tools and testing dependencies.
 autoflake==1.4

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8.2
+python-3.9.0

--- a/scripts/check
+++ b/scripts/check
@@ -9,7 +9,7 @@ export SOURCE_FILES="server tests"
 
 set -x
 
-${PREFIX}black --check --diff --target-version=py38 $SOURCE_FILES
+${PREFIX}black --check --diff $SOURCE_FILES
 ${PREFIX}flake8 $SOURCE_FILES
 ${PREFIX}mypy $SOURCE_FILES
 ${PREFIX}isort --check --diff $SOURCE_FILES

--- a/scripts/lint
+++ b/scripts/lint
@@ -12,5 +12,5 @@ set -x
 ${PREFIX}autoflake --in-place --recursive $SOURCE_FILES
 ${PREFIX}seed-isort-config --application-directories=server
 ${PREFIX}isort $SOURCE_FILES
-${PREFIX}black --target-version=py38 $SOURCE_FILES
+${PREFIX}black $SOURCE_FILES
 ${PREFIX}python -m server.tools.mdformat


### PR DESCRIPTION
Python 3.9 support is available and:

* CI supports it.
* My `azure-pipelines-templates` now support it.
* Support was added to [Buildpack](https://github.com/heroku/heroku-buildpack-python/blob/v184/CHANGELOG.md#v182-2020-10-06)