### PR TITLE
Split deps between dev and runtime

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,19 @@
+-r requirements.txt
+
+# Development, tools and testing dependencies.
+autoflake==1.4
+asgi-lifespan==1.0.1
+black==20.8b1
+exdown==0.7.1
+flake8==3.8.4
+flake8-bugbear==20.1.4
+flake8-comprehensions==3.3.0
+flake8-pie==0.6.1
+httpx==0.15.5
+isort==5.5.4
+mypy==0.782
+Pillow==8.0.1
+pytest==6.1.1
+pytest-asyncio==0.14.0
+pytest-cov==2.10.1
+seed-isort-config==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Application dependencies.
+# Runtime dependencies.
 aiofiles==0.6.0
 arel==0.2.0
 asgi-sitemaps==0.3.2
@@ -9,21 +9,3 @@ pygments==2.7.1
 python-frontmatter==0.5.0
 starlette==0.13.8
 uvicorn[standard]==0.12.3
-
-# Development, tools and testing dependencies.
-autoflake==1.4
-asgi-lifespan==1.0.1
-black==20.8b1
-exdown==0.7.1
-flake8==3.8.4
-flake8-bugbear==20.1.4
-flake8-comprehensions==3.3.0
-flake8-pie==0.6.1
-httpx==0.15.5
-isort==5.5.4
-mypy==0.782
-Pillow==8.0.1
-pytest==6.1.1
-pytest-asyncio==0.14.0
-pytest-cov==2.10.1
-seed-isort-config==2.2.0

--- a/scripts/install
+++ b/scripts/install
@@ -1,21 +1,13 @@
 #!/bin/bash
 
-note() { echo "-----> $@"; }
-ci_detected() { note "CI pipeline detected: $@"; }
-
 if [ -z $CI ]; then
   export PREFIX="venv/bin/"
 
   if [ ! -d venv ]; then
-    note "Create virtual environment"
     python -m venv venv
-
-    note "Upgrade pip"
-    ${PREFIX}pip install -U pip
   fi
 
   if ! [ -f .env ]; then
-    note "Add .env"
     echo "# App configuration." >> .env
     echo "DEBUG=true" >> .env
     echo 'DD_TAGS="env:local"' >> .env
@@ -24,20 +16,12 @@ if [ -z $CI ]; then
     echo "PORT=8000" >> .env
   fi
 else
-  ci_detected "Using system Python executables"
   export PREFIX=""
 fi
 
-# Prevent falling back to legacy 'setup.py install' for wheels.
-note "Upgrade package 'wheel'"
-${PREFIX}pip install -U wheel
-
-note "Install pip dependencies"
-${PREFIX}pip install --use-feature="2020-resolver" -r requirements.txt
+${PREFIX}pip install -U pip wheel
+${PREFIX}pip install -r requirements-dev.txt
 
 if [ -z $CI ]; then
-  note "Install yarn dependencies"
   yarn install
-else
-  ci_detected "Skipping yarn dependencies"
 fi


### PR DESCRIPTION
**Description**
* Split `requirements.txt` into `requirements.txt` and `requirements-dev.txt`.
* Also update and simplify `scripts/install`.

**Motivation**
Speed up deploys by skipping installation / compilation of test/dev dependencies.
