### PR TITLE
Add support for including extra content directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ scripts/deploy
 | -------------------- | ------------------------------------------------------------------------ | ------- |
 | `DEBUG`              | Run in debug mode. Enables in-browser tracebacks and content hot reload. | `False` |
 | `TESTING`            | Run against mocked resources.                                            | `False` |
+| `EXTRA_CONTENT_DIRS` | Include content from extra directories.                                  | None    |
 
 ## License
 

--- a/server/content.py
+++ b/server/content.py
@@ -14,19 +14,21 @@ async def load_content() -> None:
     resources.index.pages = build_pages(items)
 
 
-def iter_content_paths() -> Iterator[Path]:
-    pattern = str(settings.CONTENT_DIR / "**" / "*.md")
-    for path in glob.glob(pattern, recursive=True):
-        yield Path(path)
+def iter_content_paths() -> Iterator[Tuple[Path, Path]]:
+    content_dirs = [settings.CONTENT_DIR, *settings.EXTRA_CONTENT_DIRS]
+    for root in content_dirs:
+        pattern = str(root / "**" / "*.md")
+        for path in glob.glob(pattern, recursive=True):
+            yield root, Path(path)
 
 
 async def load_content_items() -> AsyncIterator[ContentItem]:
-    for path in iter_content_paths():
+    for root, path in iter_content_paths():
         async with aiofiles.open(path) as f:
             content = await f.read()
             yield ContentItem(
                 content=content,
-                location=str(path.relative_to(settings.CONTENT_DIR)),
+                location=str(path.relative_to(root)),
             )
 
 

--- a/server/settings.py
+++ b/server/settings.py
@@ -2,6 +2,7 @@ import json
 import pathlib
 
 from starlette.config import Config
+from starlette.datastructures import CommaSeparatedStrings
 
 from .markdown import ImageFigcaptions
 
@@ -25,6 +26,12 @@ KNOWN_DOMAINS = [
 STATIC_ROOT = "/static"
 STATIC_DIR = HERE / "static"
 TEMPLATES_DIR = HERE / "templates"
+
+EXTRA_CONTENT_DIRS = config(
+    "EXTRA_CONTENT_DIRS",
+    cast=lambda v: [pathlib.Path(item) for item in CommaSeparatedStrings(v)],
+    default="",
+)
 
 # Images take too much room on the Web. Let's limit ourselves
 # to reasonable sizes only.

--- a/server/tools/mdformat.py
+++ b/server/tools/mdformat.py
@@ -102,4 +102,4 @@ if __name__ == "__main__":  # pragma: no cover
         help="Fail if files would be reformatted.",
     )
     args = parser.parse_args()
-    sys.exit(main(iter_content_paths(), check=args.check))
+    sys.exit(main([path for _, path in iter_content_paths()], check=args.check))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from starlette.types import ASGIApp
 
 os.environ["TESTING"] = "True"
 os.environ["DEBUG"] = "False"
+os.environ["EXTRA_CONTENT_DIRS"] = "tests/drafts"
 
 
 @pytest.fixture(scope="session")

--- a/tests/drafts/articles/2020/01/test-draft.md
+++ b/tests/drafts/articles/2020/01/test-draft.md
@@ -1,0 +1,11 @@
+---
+published: true
+title: "Test"
+description: "A test draft."
+date: "2020-01-01"
+category: essays
+tags:
+  - test
+---
+
+Test draft.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -40,6 +40,13 @@ async def test_tag(client: httpx.AsyncClient) -> None:
     assert "text/html" in resp.headers["content-type"]
 
 
+async def test_extra_content_dirs(client: httpx.AsyncClient) -> None:
+    url = "http://florimond.dev/blog/articles/2020/01/test-draft/"
+    resp = await client.get(url, allow_redirects=False)
+    assert resp.status_code == 200, resp.url
+    assert "text/html" in resp.headers["content-type"]
+
+
 KNOWN_CATEGORIES = ["tutorials", "essays", "retrospectives"]
 
 


### PR DESCRIPTION
**Motivation**
I can now keep drafts in a git-ignored `debug/drafts` folder, put `EXTRA_CONTENT_DIRS=debug/drafts` in my `.env` file, and have them served along with regular content. Allows me to manage drafts without having to do git branching.