### PR TITLE
Use absolute image paths for meta images

### DIFF
--- a/server/content.py
+++ b/server/content.py
@@ -7,6 +7,7 @@ import frontmatter as fm
 
 from . import resources, settings
 from .models import ContentItem, Frontmatter, MetaTag, Page
+from .utils import to_production_url
 
 
 async def load_content() -> None:
@@ -166,18 +167,21 @@ def _build_permalink(location: str) -> str:
 def _build_meta(permalink: str, frontmatter: Frontmatter) -> List["MetaTag"]:
     url = f"https://florimond.dev/blog{permalink}"
 
+    image_url = frontmatter.image
+    if image_url:
+        image_url = to_production_url(image_url)
+
     meta = [
         # General
         MetaTag(name="description", content=frontmatter.description),
-        MetaTag(name="image", content=frontmatter.image),
+        MetaTag(name="image", content=image_url),
         MetaTag(itemprop="name", content=frontmatter.title),
         MetaTag(itemprop="description", content=frontmatter.description),
-        MetaTag(itemprop="image", content=frontmatter.image),
         # Twitter
         MetaTag(name="twitter:url", content=url),
         MetaTag(name="twitter:title", content=frontmatter.title),
         MetaTag(name="twitter:description", content=frontmatter.description),
-        MetaTag(name="twitter:image", content=frontmatter.image),
+        MetaTag(name="twitter:image", content=image_url),
         MetaTag(name="twitter:card", content="summary_large_image"),
         MetaTag(name="twitter:site", content="@florimondmanca"),
         # OpenGraph
@@ -185,7 +189,7 @@ def _build_meta(permalink: str, frontmatter: Frontmatter) -> List["MetaTag"]:
         MetaTag(property="og:type", content="article"),
         MetaTag(property="og:title", content=frontmatter.title),
         MetaTag(property="og:description", content=frontmatter.description),
-        MetaTag(property="og:image", content=frontmatter.image),
+        MetaTag(property="og:image", content=image_url),
         MetaTag(property="og:site_name", content=settings.SITE_TITLE),
         MetaTag(property="article:published_time", content=frontmatter.date),
     ]

--- a/server/utils.py
+++ b/server/utils.py
@@ -1,3 +1,5 @@
+import httpx
+
 from . import settings
 
 
@@ -14,3 +16,8 @@ def is_static_asset(path: str) -> bool:
         return True
 
     return False
+
+
+def to_production_url(url: str) -> str:
+    urlobj = httpx.URL(url)
+    return str(urlobj.copy_with(scheme="https", host="florimond.dev", port=None))

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -17,6 +17,7 @@ def test_build_pages() -> None:
     description = "How readability impacts software development."
     date = "2000-01-01"
     category = "essays"
+    image = "/static/img/articles/example.jpg"
 
     items = [
         ContentItem(
@@ -30,6 +31,7 @@ def test_build_pages() -> None:
                 category: {category}
                 tags:
                 - python
+                image: "{image}"
                 ---
                 You should *really* care about readability.
                 """
@@ -49,6 +51,7 @@ def test_build_pages() -> None:
     assert readability_counts.frontmatter.date == date
     assert readability_counts.frontmatter.category == category
     assert readability_counts.frontmatter.tags == ["python"]
+    assert readability_counts.frontmatter.image == image
     assert not readability_counts.frontmatter.home
 
     meta = [str(tag) for tag in readability_counts.meta]
@@ -57,6 +60,7 @@ def test_build_pages() -> None:
     assert f'<meta name="twitter:title" content="{title}">' in meta
     assert f'<meta name="twitter:description" content="{description}">' in meta
     assert f'<meta name="twitter:url" content="{url}">' in meta
+    assert f'<meta name="twitter:image" content="https://florimond.dev{image}">' in meta
     assert '<meta property="article:tag" content="python">' in meta
 
     assert readability_counts.html == (


### PR DESCRIPTION
Right now crawlers request `/static/img/...`, we need them to request `https://florimond.dev/static/img/...`.

This holds because all images are now hosted on the domain, as per #118.