### PR TITLE
Add translations infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 .mypy_cache
 .pytest_cache
 *.egg-info
+*.mo
 
 # Sass
 .sass-cache

--- a/babel.cfg
+++ b/babel.cfg
@@ -1,0 +1,3 @@
+[python: **.py]
+[jinja2: **/templates/**.jinja]
+extensions=jinja2.ext.autoescape,jinja2.ext.with_

--- a/locale/base.pot
+++ b/locale/base.pot
@@ -1,0 +1,66 @@
+# Translations template for PROJECT.
+# Copyright (C) 2021 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2021-04-22 13:50+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.0\n"
+
+#: server/content.py:128
+msgid "Tutorials"
+msgstr ""
+
+#: server/content.py:129
+msgid "Essays"
+msgstr ""
+
+#: server/content.py:130
+msgid "Retrospectives"
+msgstr ""
+
+#: server/templates/components/jumbotron.jinja:13
+#: server/templates/views/home.jinja:13 server/templates/views/home.jinja:27
+msgid "Open Source Developer, Idealist On A Journey"
+msgstr ""
+
+#: server/templates/components/jumbotron.jinja:16
+msgid ""
+"I maintain and contribute to libraries, packages, and tools. Mostly "
+"Python."
+msgstr ""
+
+#: server/templates/components/social_links.jinja:3
+msgid "Links"
+msgstr ""
+
+#: server/templates/components/pages/article_meta.jinja:8
+msgid "in"
+msgstr ""
+
+#: server/templates/components/pages/article_meta.jinja:24
+msgid "Edit"
+msgstr ""
+
+#: server/templates/components/pages/page_list.jinja:10
+msgid "No articles yet."
+msgstr ""
+
+#: server/templates/views/404.jinja:7
+msgid "Page not found."
+msgstr ""
+
+#: server/templates/views/500.jinja:7
+msgid "Internal server error."
+msgstr ""
+

--- a/locale/fr_FR/LC_MESSAGES/messages.po
+++ b/locale/fr_FR/LC_MESSAGES/messages.po
@@ -1,0 +1,69 @@
+# French (France) translations for PROJECT.
+# Copyright (C) 2021 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2021-04-22 13:50+0200\n"
+"PO-Revision-Date: 2021-04-22 12:40+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: fr_FR\n"
+"Language-Team: fr_FR <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n > 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.0\n"
+
+#: server/content.py:128
+msgid "Tutorials"
+msgstr "Tutoriels"
+
+#: server/content.py:129
+msgid "Essays"
+msgstr "Écrits"
+
+#: server/content.py:130
+msgid "Retrospectives"
+msgstr "Rétrospectives"
+
+#: server/templates/components/jumbotron.jinja:13
+#: server/templates/views/home.jinja:13 server/templates/views/home.jinja:27
+msgid "Open Source Developer, Idealist On A Journey"
+msgstr "Ingénieur logiciel et open source"
+
+#: server/templates/components/jumbotron.jinja:16
+msgid ""
+"I maintain and contribute to libraries, packages, and tools. Mostly "
+"Python."
+msgstr ""
+"Je gère et contribue à des librairies, paquets et outils, principalement "
+"en Python."
+
+#: server/templates/components/social_links.jinja:3
+msgid "Links"
+msgstr "Liens"
+
+#: server/templates/components/pages/article_meta.jinja:8
+msgid "in"
+msgstr "dans"
+
+#: server/templates/components/pages/article_meta.jinja:24
+msgid "Edit"
+msgstr "Éditer"
+
+#: server/templates/components/pages/page_list.jinja:10
+msgid "No articles yet."
+msgstr "Pas encore d'articles."
+
+#: server/templates/views/404.jinja:7
+msgid "Page not found."
+msgstr "Cette page est introuvable."
+
+#: server/templates/views/500.jinja:7
+msgid "Internal server error."
+msgstr "Erreur interne."
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 aiofiles==0.6.0
 arel==0.2.0
 asgi-sitemaps==0.3.2
+babel==2.9.0
 gunicorn==20.0.4
 httpx==0.15.5
 jinja2==2.11.3

--- a/scripts/compilemessages
+++ b/scripts/compilemessages
@@ -1,0 +1,13 @@
+#!/bin/sh -e
+
+export PREFIX=""
+if [ -d "venv" ] ; then
+    export PREFIX="venv/bin/"
+fi
+
+DOMAIN="messages"
+LOCALE_DIR="locale"
+
+set -x
+
+${PREFIX}pybabel compile --domain $DOMAIN -d $LOCALE_DIR

--- a/scripts/makemessages
+++ b/scripts/makemessages
@@ -1,0 +1,23 @@
+#!/bin/sh -e
+
+export PREFIX=""
+if [ -d "venv" ] ; then
+    export PREFIX="venv/bin/"
+fi
+
+LOCALE_DIR="locale"
+BASE_FILE="$LOCALE_DIR/base.pot"
+INIT_MARKER_FILE="$LOCALE_DIR/.init"
+
+set -x
+
+mkdir -p $LOCALE_DIR
+
+${PREFIX}pybabel extract -F babel.cfg -o $BASE_FILE ./server/
+
+if [ -f $INIT_MARKER_FILE ]; then
+    ${PREFIX}pybabel update -i $BASE_FILE -d $LOCALE_DIR
+else
+    ${PREFIX}pybabel init -l fr_FR -i $BASE_FILE -d $LOCALE_DIR
+    touch $INIT_MARKER_FILE
+fi

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,3 +1,10 @@
-from .app import app
+from . import i18n, settings
+
+i18n.load_translations(
+    directory=str(settings.LOCALES_DIR),
+    domain=settings.LOCALES_DOMAIN,
+)
+
+from .app import app  # noqa: E402
 
 __all__ = ["app"]

--- a/server/content.py
+++ b/server/content.py
@@ -6,6 +6,7 @@ import aiofiles
 import frontmatter as fm
 
 from . import resources, settings
+from .i18n import gettext_lazy as _
 from .models import ContentItem, Frontmatter, MetaTag, Page
 from .utils import to_production_url
 
@@ -113,7 +114,7 @@ def _append_filename(filename: str, suffix: str) -> str:
 def _generate_tag_pages(tags: Iterable[str]) -> Iterator[Page]:
     for tag in tags:
         frontmatter = Frontmatter(
-            title=f"{tag.capitalize()} - {settings.SITE_TITLE}",
+            title=f"{tag.capitalize()} - Florimond Manca",
             description=f"Articles about #{tag}",
             tag=tag,
         )
@@ -124,15 +125,15 @@ def _generate_tag_pages(tags: Iterable[str]) -> Iterator[Page]:
 
 
 _CATEGORY_LABELS = {
-    "tutorials": "Tutorials",
-    "essays": "Essays",
-    "retrospectives": "Retrospectives",
+    "tutorials": _("Tutorials"),
+    "essays": _("Essays"),
+    "retrospectives": _("Retrospectives"),
 }
 
 
 def get_category_label(value: str) -> str:
     try:
-        return _CATEGORY_LABELS[value]
+        return str(_CATEGORY_LABELS[value])
     except KeyError:
         raise ValueError(
             f"Unknown category value: {value!r} (available: {list(_CATEGORY_LABELS)})"
@@ -143,7 +144,7 @@ def _generate_category_pages(categories: Iterable[str]) -> Iterator[Page]:
     for category in categories:
         label = get_category_label(category)
         frontmatter = Frontmatter(
-            title=f"{label} - {settings.SITE_TITLE}",
+            title=f"{label} - Florimond Manca",
             description=label,
             category=category,
         )
@@ -189,7 +190,7 @@ def _build_meta(permalink: str, frontmatter: Frontmatter) -> List["MetaTag"]:
         MetaTag(property="og:title", content=frontmatter.title),
         MetaTag(property="og:description", content=frontmatter.description),
         MetaTag(property="og:image", content=image_url),
-        MetaTag(property="og:site_name", content=settings.SITE_TITLE),
+        MetaTag(property="og:site_name", content="Florimond Manca"),
         MetaTag(property="article:published_time", content=frontmatter.date),
     ]
 

--- a/server/i18n/__init__.py
+++ b/server/i18n/__init__.py
@@ -1,0 +1,16 @@
+from .datetime import dateformat
+from .gettext import gettext_lazy
+from .jinja2 import setup_jinja2
+from .locale import Locale, load_translations
+from .middleware import LocaleMiddleware
+from .routing import LocaleRoute
+
+__all__ = [
+    "dateformat",
+    "gettext_lazy",
+    "load_translations",
+    "Locale",
+    "LocaleMiddleware",
+    "LocaleRoute",
+    "setup_jinja2",
+]

--- a/server/i18n/datetime.py
+++ b/server/i18n/datetime.py
@@ -1,0 +1,10 @@
+import datetime as dt
+
+from babel.dates import format_date
+
+from .locale import Locale
+
+
+def dateformat(d: dt.datetime) -> str:
+    locale = Locale.get()
+    return format_date(d, locale=locale, format="long")

--- a/server/i18n/gettext.py
+++ b/server/i18n/gettext.py
@@ -1,0 +1,16 @@
+from babel.support import LazyProxy
+
+from .locale import Locale
+
+
+def gettext(message: str) -> str:
+    locale = Locale.get()
+    return locale.gettext(message)
+
+
+def ngettext(singular: str, plural: str, count: int) -> str:
+    raise NotImplementedError  # pragma: no cover
+
+
+def gettext_lazy(string: str) -> LazyProxy:
+    return LazyProxy(gettext, string, enable_cache=False)

--- a/server/i18n/jinja2.py
+++ b/server/i18n/jinja2.py
@@ -1,0 +1,8 @@
+from typing import Any
+
+from .gettext import gettext, ngettext
+
+
+def setup_jinja2(env: Any) -> None:
+    env.add_extension("jinja2.ext.i18n")
+    env.install_gettext_callables(gettext, ngettext, newstyle=True)

--- a/server/i18n/locale.py
+++ b/server/i18n/locale.py
@@ -1,0 +1,94 @@
+import logging
+import os
+from contextvars import ContextVar
+from typing import Dict, Set, Union
+
+from babel.core import Locale as _Locale
+from babel.core import negotiate_locale
+from babel.support import NullTranslations, Translations
+
+from .. import settings
+
+logger = logging.getLogger("uvicorn.error")
+
+
+class _GettextTranslations:
+    def __init__(self, default: str) -> None:
+        self._default = default
+        self._translations: Dict[str, Union[Translations, NullTranslations]] = {}
+        self._supported_locales: Set[str] = set()
+
+    @property
+    def translations(
+        self,
+    ) -> Dict[str, Union[Translations, NullTranslations]]:
+        return self._translations
+
+    @property
+    def supported_locales(self) -> Set[str]:
+        return self._supported_locales
+
+    @property
+    def default_locale(self) -> str:
+        return self._default
+
+    def load(self, directory: str, domain: str) -> None:
+        for lang in os.listdir(directory):
+            if os.path.isfile(os.path.join(directory, lang)):
+                continue
+            translation = Translations.load(directory, [lang], domain)
+            assert lang not in self._translations
+            self._translations[lang] = translation
+
+        self._supported_locales = set(self._translations.keys())
+        self._supported_locales.add(self.default_locale)
+
+        logger.info("Supported locales: %s", sorted(self._supported_locales))
+
+
+_GETTEXT_TRANSLATIONS = _GettextTranslations(default=settings.DEFAULT_LANGUAGE)
+
+
+def load_translations(directory: str, domain: str) -> None:
+    _GETTEXT_TRANSLATIONS.load(directory, domain)
+
+
+class Locale(_Locale):
+    _LANGUAGE_CTX: ContextVar["Locale"] = ContextVar("language")
+    _DEFAULT = _GETTEXT_TRANSLATIONS.default_locale
+
+    @classmethod
+    def _make(cls, code: str) -> "Locale":
+        # Eg 'fr' should be negotiated as 'fr_FR'
+        # NOTE: don't use `cls.negotiate()` as it returns a hardcoded
+        # Babel `Locale` instance.
+        identifier = negotiate_locale(
+            preferred=[code],
+            available=_GETTEXT_TRANSLATIONS.supported_locales,
+        )
+        if identifier is None:
+            raise RuntimeError("Unsupported locale: {code!r}")  # pragma: no cover
+
+        locale = cls.parse(identifier)
+        translations = _GETTEXT_TRANSLATIONS.translations.get(
+            identifier, NullTranslations()
+        )
+        locale.translations = translations
+
+        return locale
+
+    def gettext(self, message: str) -> str:
+        return self.translations.ugettext(message)
+
+    @classmethod
+    def get(cls) -> "Locale":
+        try:
+            return cls._LANGUAGE_CTX.get()
+        except LookupError:
+            return cls._make(cls._DEFAULT)
+
+    @classmethod
+    def set(cls, code: str) -> None:
+        locale = cls._make(code)
+        logger.debug("Locale.set locale=%s", locale)
+        cls._LANGUAGE_CTX.set(locale)

--- a/server/i18n/middleware.py
+++ b/server/i18n/middleware.py
@@ -1,0 +1,43 @@
+from typing import List
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+from .locale import Locale
+
+
+class LocaleMiddleware(BaseHTTPMiddleware):
+    def __init__(
+        self,
+        app: ASGIApp,
+        languages: List[str],
+        default_language: str,
+    ) -> None:
+        super().__init__(app)
+        self._languages = languages
+        self._default_language = default_language
+
+    def _get_language(self, request: Request) -> str:
+        for language in self._languages:
+            language_prefix = f"/{language}"
+            if request.url.path.startswith(language_prefix):
+                return language
+
+        try:
+            return request.headers["Accept-Language"]
+        except KeyError:
+            pass
+
+        return self._default_language
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        language = self._get_language(request)
+
+        if language in self._languages:
+            Locale.set(language)
+
+        return await call_next(request)

--- a/server/i18n/routing.py
+++ b/server/i18n/routing.py
@@ -1,0 +1,54 @@
+# from typing import Any, Tuple
+from typing import Tuple
+
+from starlette import status
+from starlette.datastructures import URL, Scope, URLPath
+from starlette.responses import RedirectResponse
+from starlette.routing import Match, Route
+from starlette.types import Receive, Send
+
+from .. import settings
+from .locale import Locale
+
+
+class LocaleRoute(Route):
+    def matches(self, scope: Scope) -> Tuple[Match, Scope]:
+        if scope["type"] != "http":
+            # Eg hot-reload WebSocket.
+            return super().matches(scope)
+
+        # Drop any language prefix for matching.
+        # For example, LocaleRoute("/blog") should match "/fr/blog".
+        path = scope["path"]
+        for language in settings.LANGUAGES:
+            language_prefix = f"/{language}"
+            if path.startswith(language_prefix):
+                scope = {**scope, "path": path[len(language_prefix) :]}
+                break
+        else:
+            # If no language prefix is present, assume redirection to default language.
+            scope["redirect_default_language"] = True
+
+        return super().matches(scope)
+
+    def url_path_for(self, name: str, **path_params: str) -> URLPath:
+        # Automatically prepend language prefix to reversed URLs.
+        # Accept magic 'lang' path parameter to set language
+        # explicitly: `url_for(..., lang=...)`.
+        language = path_params.pop("lang", Locale.get().language)
+        url_path = super().url_path_for(name, **path_params)
+        return URLPath(f"/{language}{url_path}")
+
+    async def handle(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if "redirect_default_language" in scope:
+            # Example: '/blog/...' -> '/en/blog/...'
+            prefix = f"/{settings.DEFAULT_LANGUAGE}"
+            redirect_path = prefix + scope["path"]
+            response = RedirectResponse(
+                URL(scope=scope).replace(path=redirect_path),
+                status_code=status.HTTP_307_TEMPORARY_REDIRECT,
+            )
+            await response(scope, receive, send)
+            return
+
+        await super().handle(scope, receive, send)

--- a/server/middleware.py
+++ b/server/middleware.py
@@ -6,7 +6,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 from starlette.types import ASGIApp
 
-from . import legacy, settings
+from . import i18n, legacy, settings
 
 middleware = [
     # NOTE: Middleware executes from top to bottom.
@@ -14,6 +14,11 @@ middleware = [
         legacy.LegacyRedirectMiddleware,
         url_mapping=settings.LEGACY_URL_MAPPING,
         root_path="/blog",
+    ),
+    Middleware(
+        i18n.LocaleMiddleware,
+        languages=settings.LANGUAGES,
+        default_language=settings.DEFAULT_LANGUAGE,
     ),
 ]
 

--- a/server/resources.py
+++ b/server/resources.py
@@ -5,7 +5,7 @@ from starlette.exceptions import HTTPException
 from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 
-from . import settings
+from . import i18n, settings
 from .models import Index
 from .reload import hotreload
 
@@ -18,8 +18,8 @@ def raise_server_error(message: str) -> None:  # pragma: no cover
 
 
 def dateformat(value: str) -> str:
-    datevalue = dt.datetime.strptime(value, "%Y-%m-%d")
-    return datevalue.strftime("%b %d, %Y")
+    d = dt.datetime.strptime(value, "%Y-%m-%d")
+    return i18n.dateformat(d)
 
 
 def category_label(value: str) -> str:
@@ -27,6 +27,8 @@ def category_label(value: str) -> str:
 
     return get_category_label(value)
 
+
+i18n.setup_jinja2(templates.env)
 
 templates.env.globals["now"] = dt.datetime.now
 templates.env.globals["raise"] = raise_server_error

--- a/server/routes.py
+++ b/server/routes.py
@@ -1,6 +1,6 @@
 from starlette.routing import Host, Mount, Route, WebSocketRoute
 
-from . import legacy, middleware, resources, settings, views
+from . import i18n, legacy, middleware, resources, settings, views
 from .reload import hotreload
 from .sitemap import sitemap
 
@@ -20,10 +20,10 @@ routes = [
         app=legacy.DomainRedirect("florimond.dev", root_path="/blog"),
         name="legacy:blog_dot_dev",
     ),
-    Route("/", views.home),
+    i18n.LocaleRoute("/", views.home, name="home"),
     Route("/error/", views.error),
     Route("/blog/", views.legacy_blog_home, name="legacy:blog_home"),
-    Route("/blog/{permalink:path}/", views.RenderPage, name="page"),
+    i18n.LocaleRoute("/blog/{permalink:path}/", views.RenderPage, name="page"),
     Mount(settings.STATIC_ROOT, resources.static, name="static"),
     # These files need to be exposed at the root, not '/static/'.
     Route("/favicon.ico", resources.static, name="favicon"),

--- a/server/settings.py
+++ b/server/settings.py
@@ -10,10 +10,9 @@ config = Config(".env")
 
 HERE = pathlib.Path(__file__).parent
 
+
 DEBUG: bool = config("DEBUG", cast=bool, default=False)
 TESTING: bool = config("TESTING", cast=bool, default=False)
-
-SITE_TITLE = "Florimond Manca"
 
 KNOWN_DOMAINS = [
     "localhost",
@@ -26,6 +25,11 @@ KNOWN_DOMAINS = [
 STATIC_ROOT = "/static"
 STATIC_DIR = HERE / "static"
 TEMPLATES_DIR = HERE / "templates"
+
+LOCALES_DIR = HERE.parent / "locale"
+LOCALES_DOMAIN = "messages"
+LANGUAGES = ["en", "fr"]
+DEFAULT_LANGUAGE = "en"
 
 EXTRA_CONTENT_DIRS = config(
     "EXTRA_CONTENT_DIRS",

--- a/server/templates/base.jinja
+++ b/server/templates/base.jinja
@@ -11,7 +11,7 @@
     />
     <meta name="author" content="Florimond Manca" />
 
-    <title>{% block title %}{{ settings.SITE_TITLE }}{% endblock title %}</title>
+    <title>{% block title %}Florimond Manca{% endblock title %}</title>
 
     <!-- PWA Manifest -->
     <link rel="manifest" href="{{ url_for('static', path='/manifest.json') }}" />
@@ -29,7 +29,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
 
     <!-- RSS -->
-    <link rel="alternate" type="application/rss+xml" href="https://florimond.dev/feed.rss" title="{{ settings.SITE_TITLE }} - RSS Feed">
+    <link rel="alternate" type="application/rss+xml" href="https://florimond.dev/feed.rss" title="Florimond Manca - RSS Feed">
 
     <!-- Custom CSS -->
     <link rel="stylesheet" href="{{ url_for('static', path='/css/styles.css') }}">

--- a/server/templates/components/jumbotron.jinja
+++ b/server/templates/components/jumbotron.jinja
@@ -10,10 +10,10 @@
         Florimond Manca
       </h1>
       <h2 class="text-xl">
-        Open Source Developer, Idealist On A Journey
+        {% trans %}Open Source Developer, Idealist On A Journey{% endtrans %}
       </h2>
       <p class="text-muted mb-3">
-        I maintain and contribute to libraries, packages, and tools. Mostly Python.
+        {% trans %}I maintain and contribute to libraries, packages, and tools. Mostly Python.{% endtrans %}
       </p>
     </div>
   </div>

--- a/server/templates/components/navbar.jinja
+++ b/server/templates/components/navbar.jinja
@@ -4,17 +4,27 @@
 <nav class="p-page-content">
   {% call ContentWrapper(class="text-center tablet:flex tablet:items-center") %}
     <a class="inline-block text-lg font-bold py-2 pr-3" href="{{ url_for('home') }}">
-      {{ settings.SITE_TITLE }}
+      Florimond Manca
     </a>
-    <ul class="flex justify-center">
-      {% for page in get_category_pages() %}
-      <li>
-        <a class="px-4" href="{{ url_for('page', permalink=page.permalink.lstrip('/')) }}">
-          {{ page.frontmatter.category | category_label }}
-        </a>
-      </li>
-      {% endfor %}
-    </ul>
+    <div class="flex flex-grow justify-between">
+      <ul class="flex justify-center">
+        {% for page in get_category_pages() %}
+        <li>
+          <a class="px-4" href="{{ url_for('page', permalink=page.permalink.lstrip('/')) }}">
+            {{ page.frontmatter.category | category_label }}
+          </a>
+        </li>
+        {% endfor %}
+      </ul>
+      {% if lang_switch %}
+      <div class="flex flex-end">
+        {% for (lang, url) in lang_switch %}
+          <a href="{{ url }}">{{ lang.upper() }}</a>
+          {% if not loop.last %}/{% endif %}
+        {% endfor %}
+      </div>
+      {% endif %}
+    </div>
   {% endcall %}
 </nav>
 {% endmacro %}

--- a/server/templates/components/pages/article_meta.jinja
+++ b/server/templates/components/pages/article_meta.jinja
@@ -5,8 +5,8 @@
   <div class="text-muted pr-3">
     {{ page.frontmatter.date | dateformat }}
     |
-    in
-    <a href="{{ url_for('page', permalink='/category/' + page.frontmatter.category) }}">
+    {{ _('in') }}
+    <a href="{{ url_for('page', permalink='category/' + page.frontmatter.category) }}">
       {{ page.frontmatter.category | category_label }}
     </a>
   </div>
@@ -21,7 +21,7 @@
   rel="no-referrer"
   target="_blank"
 >
-  📝&nbsp;Edit
+  📝&nbsp;{% trans %}Edit{% endtrans %}
 </a>
 {% endif %}
 {% endmacro %}

--- a/server/templates/components/pages/page_list.jinja
+++ b/server/templates/components/pages/page_list.jinja
@@ -7,7 +7,7 @@
   {%- else -%}
 </ul>
   <p>
-    No articles yet.
+    {% trans %}No articles yet.{% endtrans %}
   </p>
 {%- endfor %}
 {% endmacro %}

--- a/server/templates/components/social_links.jinja
+++ b/server/templates/components/social_links.jinja
@@ -1,6 +1,6 @@
 {% macro SocialLinks() %}
 <p class="font-bold">
-  Links
+  {% trans %}Links{% endtrans %}
 </p>
 
 <ul class="flex flex-row justify-center items-center">

--- a/server/templates/views/404.jinja
+++ b/server/templates/views/404.jinja
@@ -4,7 +4,7 @@
 <main role="main">
   <div class="mt-6 text-center">
     <h1>404</h1>
-    <p>Page not found.</p>
+    <p>{% trans %}Page not found.{% endtrans %}</p>
   </div>
 </main>
 {% endblock %}

--- a/server/templates/views/500.jinja
+++ b/server/templates/views/500.jinja
@@ -4,7 +4,7 @@
 <main role="main">
   <div class="mt-6 text-center">
     <h1>500</h1>
-    <p>Internal server error.</p>
+    <p>{% trans %}Internal server error.{% endtrans %}</p>
   </div>
 </main>
 {% endblock %}

--- a/server/templates/views/home.jinja
+++ b/server/templates/views/home.jinja
@@ -7,10 +7,10 @@
 {% block head %}
   <!-- Twitter card -->
   <meta name="twitter:card" content="summary" />
-  <meta name="twitter:title" content="{{ settings.SITE_TITLE }}" />
+  <meta name="twitter:title" content="Florimond Manca" />
   <meta
     name="twitter:description"
-    content="Open Source Developer & Idealist On A Journey"
+    content="{% trans %}Open Source Developer, Idealist On A Journey{% endtrans %}"
   />
   <meta name="twitter:site" content="@florimondmanca" />
   <meta name="twitter:creator" content="@florimondmanca" />
@@ -21,10 +21,10 @@
   />
 
   <!-- OpenGraph card -->
-  <meta property="og:title" content="{{ settings.SITE_TITLE }}" />
+  <meta property="og:title" content="Florimond Manca" />
   <meta
     property="og:description"
-    content="Open Source Developer & Idealist On A Journey"
+    content="{% trans %}Open Source Developer, Idealist On A Journey{% endtrans %}"
   />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="{{ request.url }}" />

--- a/server/templates/views/page.jinja
+++ b/server/templates/views/page.jinja
@@ -12,7 +12,7 @@
 {% endblock head %}
 
 {% block title %}
-  {{ page.frontmatter.title or settings.SITE_TITLE }}
+  {{ page.frontmatter.title or 'Florimond Manca' }}
 {% endblock title %}
 
 {% block content %}

--- a/server/views.py
+++ b/server/views.py
@@ -14,7 +14,10 @@ def _common_context() -> dict:
 
 
 async def home(request: Request) -> Response:
-    context = {"request": request, **_common_context()}
+    lang_switch = [
+        (lang, request.url_for("home", lang=lang)) for lang in settings.LANGUAGES
+    ]
+    context = {"request": request, "lang_switch": lang_switch, **_common_context()}
     return resources.templates.TemplateResponse("views/home.jinja", context=context)
 
 
@@ -32,7 +35,17 @@ class RenderPage(HTTPEndpoint):
         else:
             raise HTTPException(404)
 
-        context = {"request": request, "page": page, **_common_context()}
+        lang_switch = [
+            (lang, request.url_for("page", permalink=permalink.lstrip("/"), lang=lang))
+            for lang in settings.LANGUAGES
+        ]
+
+        context = {
+            "request": request,
+            "page": page,
+            "lang_switch": lang_switch,
+            **_common_context(),
+        }
 
         return resources.templates.TemplateResponse("views/page.jinja", context=context)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -11,37 +11,37 @@ pytestmark = pytest.mark.asyncio
 
 
 async def test_root(client: httpx.AsyncClient) -> None:
-    url = "http://florimond.dev/"
+    url = "http://florimond.dev/en/"
     resp = await client.get(url, allow_redirects=False)
     assert resp.status_code == 200
     assert "text/html" in resp.headers["content-type"]
 
 
 async def test_article(client: httpx.AsyncClient) -> None:
-    url = "http://florimond.dev/blog/articles/2018/07/let-the-journey-begin/"
+    url = "http://florimond.dev/en/blog/articles/2018/07/let-the-journey-begin/"
     resp = await client.get(url, allow_redirects=False)
     assert resp.status_code == 200
     assert "text/html" in resp.headers["content-type"]
 
 
 async def test_article_no_trailing_slash(client: httpx.AsyncClient) -> None:
-    url = "http://florimond.dev/blog/articles/2018/07/let-the-journey-begin"
+    url = "http://florimond.dev/en/blog/articles/2018/07/let-the-journey-begin"
     resp = await client.get(url, allow_redirects=False)
     assert resp.status_code == 307
     assert resp.headers["Location"] == (
-        "http://florimond.dev/blog/articles/2018/07/let-the-journey-begin/"
+        "http://florimond.dev/en/blog/articles/2018/07/let-the-journey-begin/"
     )
 
 
 async def test_tag(client: httpx.AsyncClient) -> None:
-    url = "http://florimond.dev/blog/tag/python/"
+    url = "http://florimond.dev/en/blog/tag/python/"
     resp = await client.get(url, allow_redirects=False)
     assert resp.status_code == 200, resp.url
     assert "text/html" in resp.headers["content-type"]
 
 
 async def test_extra_content_dirs(client: httpx.AsyncClient) -> None:
-    url = "http://florimond.dev/blog/articles/2020/01/test-draft/"
+    url = "http://florimond.dev/en/blog/articles/2020/01/test-draft/"
     resp = await client.get(url, allow_redirects=False)
     assert resp.status_code == 200, resp.url
     assert "text/html" in resp.headers["content-type"]
@@ -58,14 +58,14 @@ def test_known_categories() -> None:
 
 @pytest.mark.parametrize("category", KNOWN_CATEGORIES)
 async def test_category(client: httpx.AsyncClient, category: str) -> None:
-    url = f"http://florimond.dev/blog/category/{category}/"
+    url = f"http://florimond.dev/en/blog/category/{category}/"
     resp = await client.get(url, allow_redirects=False)
     assert resp.status_code == 200, resp.url
     assert "text/html" in resp.headers["content-type"]
 
 
 async def test_not_found(client: httpx.AsyncClient) -> None:
-    url = "http://florimond.dev/blog/foo"
+    url = "http://florimond.dev/en/blog/foo"
     resp = await client.get(url)
     assert resp.status_code == 404
     assert "text/html" in resp.headers["content-type"]
@@ -110,7 +110,7 @@ async def test_rss_link(client: httpx.AsyncClient) -> None:
 
 
 async def test_meta(client: httpx.AsyncClient) -> None:
-    url = "http://florimond.dev/blog/articles/2018/07/let-the-journey-begin/"
+    url = "http://florimond.dev/en/blog/articles/2018/07/let-the-journey-begin/"
     resp = await client.get(url, allow_redirects=False)
     assert resp.status_code == 200
     assert "text/html" in resp.headers["content-type"]

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,0 +1,52 @@
+import httpx
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_i18n_home(client: httpx.AsyncClient) -> None:
+    url = "http://florimond.dev/fr/"
+    resp = await client.get(url, allow_redirects=False)
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+
+    assert "Tutoriels" in resp.text  # Navbar
+    assert "Ingénieur logiciel" in resp.text  # Jumbotron
+    assert "25 juillet 2018" in resp.text  # Article list
+
+    # Language switch
+    assert 'href="http://florimond.dev/fr/"' in resp.text
+    assert 'href="http://florimond.dev/en/"' in resp.text
+
+
+@pytest.mark.asyncio
+async def test_i18n_article(client: httpx.AsyncClient) -> None:
+    url = "http://florimond.dev/fr/blog/articles/2018/07/let-the-journey-begin/"
+    resp = await client.get(url, allow_redirects=False)
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+
+    # Navbar
+    assert "Tutoriels" in resp.text
+
+    # Article meta
+    assert "25 juillet 2018" in resp.text
+
+    # TODO: translated content
+
+    # Language switch
+    assert (
+        'href="http://florimond.dev/fr/blog/articles/2018/07/let-the-journey-begin/"'
+        in resp.text
+    )
+    assert (
+        'href="http://florimond.dev/en/blog/articles/2018/07/let-the-journey-begin/"'
+        in resp.text
+    )
+
+
+@pytest.mark.asyncio
+async def test_i18n_unknown_language(client: httpx.AsyncClient) -> None:
+    url = "http://florimond.dev/de/"
+    resp = await client.get(url, allow_redirects=False)
+    assert resp.status_code == 404
+    assert "text/html" in resp.headers["content-type"]

--- a/tests/test_redirects.py
+++ b/tests/test_redirects.py
@@ -10,18 +10,28 @@ pytestmark = pytest.mark.asyncio
     "start_url, urls",
     [
         pytest.param(
-            "http://florimondmanca.com",
-            [("http://florimond.dev/", 301)],
+            "http://florimond.dev",
+            [
+                ("http://florimond.dev/en/", 307),
+            ],
             id="home",
+        ),
+        pytest.param(
+            "http://florimondmanca.com",
+            [
+                ("http://florimond.dev/", 301),
+                ("http://florimond.dev/en/", 307),
+            ],
+            id="legacy:home",
         ),
         pytest.param(
             "http://blog.florimondmanca.com",
             [
                 ("http://blog.florimond.dev/", 301),
                 ("http://florimond.dev/blog/", 301),
-                ("http://florimond.dev/", 307),
+                ("http://florimond.dev/en/", 307),
             ],
-            id="blog:home",
+            id="legacy:blog:home",
         ),
         pytest.param(
             "http://blog.florimondmanca.com/let-the-journey-begin",
@@ -36,12 +46,16 @@ pytestmark = pytest.mark.asyncio
                     "http://florimond.dev/blog/articles/2018/07/let-the-journey-begin/",
                     307,
                 ),
+                (
+                    "http://florimond.dev/en/blog/articles/2018/07/let-the-journey-begin/",  # noqa
+                    307,
+                ),
             ],
-            id="blog:article",
+            id="legacy:blog:article",
         ),
     ],
 )
-async def test_legacy_redirect_chains(
+async def test_redirect_chains(
     client: httpx.AsyncClient, start_url: str, urls: typing.List[str]
 ) -> None:
     resp = await client.get(start_url, allow_redirects=True)
@@ -160,7 +174,7 @@ async def test_legacy_redirect_chains(
         ),
     ],
 )
-async def test_legacy_redirect_articles(
+async def test_redirect_legacy_articles(
     client: httpx.AsyncClient,
     blog_dot_dev_path: str,
     dot_dev_path: str,
@@ -169,4 +183,4 @@ async def test_legacy_redirect_articles(
         f"https://blog.florimond.dev{blog_dot_dev_path}", allow_redirects=True
     )
     assert resp.status_code == 200
-    assert resp.url == f"https://florimond.dev/blog{dot_dev_path}"
+    assert resp.url == f"https://florimond.dev/en/blog{dot_dev_path}"

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -4,7 +4,7 @@ from server.resources import category_label, dateformat
 
 
 def test_dateformat() -> None:
-    assert dateformat("2020-07-23") == "Jul 23, 2020"
+    assert dateformat("2020-07-23") == "July 23, 2020"
 
 
 def test_category_label() -> None:


### PR DESCRIPTION
**Overview**
Add tooling for managing translations, and translate website skeleton in French.

**Details**

* Add dependency on `pybabel`
* Add `scripts/makemessages`
* Add `scripts/compilemessages`
* Add `fr_FR` website skeleton translations.
* Update templates with translations.
* Add/update tests.

**Future work**
* Add support for translating articles (eg in `content/fr/articles/...`). (Right now English articles are served.)
