### PR TITLE
Add minimal translations infrastructure

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,3 @@
+https://github.com/grauwoelfchen/heroku-buildpack-gettext.git#v0.3
 https://github.com/heroku/heroku-buildpack-nodejs.git#v172
 https://github.com/heroku/heroku-buildpack-python.git#v184

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 .mypy_cache
 .pytest_cache
 *.egg-info
+*.mo
 
 # Sass
 .sass-cache

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "dokku": {
-      "postdeploy": "scripts/compilemessages"
+      "predeploy": "scripts/compilemessages"
     }
   }
 }

--- a/app.json
+++ b/app.json
@@ -1,0 +1,7 @@
+{
+  "scripts": {
+    "dokku": {
+      "postdeploy": "scripts/compilemessages"
+    }
+  }
+}

--- a/babel.cfg
+++ b/babel.cfg
@@ -1,0 +1,3 @@
+[python: **.py]
+[jinja2: **/templates/**.jinja]
+extensions=jinja2.ext.autoescape,jinja2.ext.with_

--- a/locale/base.pot
+++ b/locale/base.pot
@@ -1,0 +1,31 @@
+# Translations template for PROJECT.
+# Copyright (C) 2021 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2021-04-22 16:27+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.0\n"
+
+#: server/content.py:128
+msgid "Tutorials"
+msgstr ""
+
+#: server/content.py:129
+msgid "Essays"
+msgstr ""
+
+#: server/content.py:130
+msgid "Retrospectives"
+msgstr ""
+

--- a/locale/fr_FR/LC_MESSAGES/messages.po
+++ b/locale/fr_FR/LC_MESSAGES/messages.po
@@ -1,0 +1,32 @@
+# French (France) translations for PROJECT.
+# Copyright (C) 2021 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2021-04-22 16:27+0200\n"
+"PO-Revision-Date: 2021-04-22 16:27+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: fr_FR\n"
+"Language-Team: fr_FR <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n > 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.0\n"
+
+#: server/content.py:128
+msgid "Tutorials"
+msgstr "Tutoriels"
+
+#: server/content.py:129
+msgid "Essays"
+msgstr "Écrits"
+
+#: server/content.py:130
+msgid "Retrospectives"
+msgstr "Rétrospectives"
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 aiofiles==0.6.0
 arel==0.2.0
 asgi-sitemaps==0.3.2
+babel==2.9.0
 gunicorn==20.0.4
 httpx==0.15.5
 jinja2==2.11.3

--- a/scripts/compilemessages
+++ b/scripts/compilemessages
@@ -1,0 +1,13 @@
+#!/bin/sh -e
+
+export PREFIX=""
+if [ -d "venv" ] ; then
+    export PREFIX="venv/bin/"
+fi
+
+DOMAIN="messages"
+LOCALE_DIR="locale"
+
+set -x
+
+${PREFIX}pybabel compile --domain $DOMAIN -d $LOCALE_DIR

--- a/scripts/install
+++ b/scripts/install
@@ -22,6 +22,8 @@ fi
 ${PREFIX}pip install -U pip wheel
 ${PREFIX}pip install -r requirements-dev.txt
 
+scripts/compilemessages
+
 if [ -z $CI ]; then
   yarn install
 fi

--- a/scripts/makemessages
+++ b/scripts/makemessages
@@ -1,0 +1,23 @@
+#!/bin/sh -e
+
+export PREFIX=""
+if [ -d "venv" ] ; then
+    export PREFIX="venv/bin/"
+fi
+
+LOCALE_DIR="locale"
+BASE_FILE="$LOCALE_DIR/base.pot"
+INIT_MARKER_FILE="$LOCALE_DIR/.init"
+
+set -x
+
+mkdir -p $LOCALE_DIR
+
+${PREFIX}pybabel extract -F babel.cfg -o $BASE_FILE ./server/
+
+if [ -f $INIT_MARKER_FILE ]; then
+    ${PREFIX}pybabel update -i $BASE_FILE -d $LOCALE_DIR
+else
+    ${PREFIX}pybabel init -l fr_FR -i $BASE_FILE -d $LOCALE_DIR
+    touch $INIT_MARKER_FILE
+fi

--- a/server/content.py
+++ b/server/content.py
@@ -6,6 +6,7 @@ import aiofiles
 import frontmatter as fm
 
 from . import resources, settings
+from .i18n import gettext_lazy as _
 from .models import ContentItem, Frontmatter, MetaTag, Page
 from .utils import to_production_url
 
@@ -124,15 +125,15 @@ def _generate_tag_pages(tags: Iterable[str]) -> Iterator[Page]:
 
 
 _CATEGORY_LABELS = {
-    "tutorials": "Tutorials",
-    "essays": "Essays",
-    "retrospectives": "Retrospectives",
+    "tutorials": _("Tutorials"),
+    "essays": _("Essays"),
+    "retrospectives": _("Retrospectives"),
 }
 
 
 def get_category_label(value: str) -> str:
     try:
-        return _CATEGORY_LABELS[value]
+        return str(_CATEGORY_LABELS[value])
     except KeyError:
         raise ValueError(
             f"Unknown category value: {value!r} (available: {list(_CATEGORY_LABELS)})"

--- a/server/i18n/__init__.py
+++ b/server/i18n/__init__.py
@@ -1,0 +1,5 @@
+from .gettext import gettext_lazy
+
+__all__ = [
+    "gettext_lazy",
+]

--- a/server/i18n/gettext.py
+++ b/server/i18n/gettext.py
@@ -1,0 +1,12 @@
+from babel.support import LazyProxy
+
+from .locale import get_locale
+
+
+def gettext(message: str) -> str:
+    locale = get_locale()
+    return locale.gettext(message)
+
+
+def gettext_lazy(string: str) -> LazyProxy:
+    return LazyProxy(gettext, string, enable_cache=False)

--- a/server/i18n/locale.py
+++ b/server/i18n/locale.py
@@ -1,0 +1,58 @@
+import logging
+from contextvars import ContextVar
+
+from babel.core import Locale as _Locale
+from babel.support import NullTranslations, Translations
+
+from .. import settings
+
+logger = logging.getLogger("uvicorn.error")
+
+# Load translations at import time, so that import-time calls to
+# gettext_lazy are properly registered.
+_translations = {
+    lang: Translations.load(str(settings.LOCALE_DIR), [lang], settings.LOCALE_DOMAIN)
+    for lang in settings.LOCALE_TRANSLATIONS
+}
+_supported_locales = {settings.DEFAULT_LANGUAGE, *_translations.keys()}
+
+logger.info("Supported locales: %s", _supported_locales)
+
+
+class Locale:
+    """
+    A convenience wrapper around a `gettext` translations object.
+    """
+
+    def __init__(self, translations: Translations = None) -> None:
+        self._translations = (
+            translations if translations is not None else NullTranslations()
+        )
+
+    def gettext(self, message: str) -> str:
+        return self._translations.ugettext(message)
+
+
+def build_locale(code: str) -> Locale:
+    # 'Negotiate' deals with 'fr' -> 'fr_FR', etc.
+    locale = _Locale.negotiate(preferred=[code], available=_supported_locales)
+
+    if locale is None:  # pragma: no cover
+        raise RuntimeError(f"Unsupported locale: {code!r}")
+
+    return Locale(translations=_translations.get(str(locale)))
+
+
+_locale_context: ContextVar["Locale"] = ContextVar(
+    "locale", default=build_locale(settings.DEFAULT_LANGUAGE)
+)
+
+
+def set_locale(code: str) -> None:
+    locale = build_locale(code)
+    logger.debug("set_locale locale=%s", locale)
+    _locale_context.set(locale)
+
+
+def get_locale() -> "Locale":
+    return _locale_context.get()

--- a/server/i18n/middleware.py
+++ b/server/i18n/middleware.py
@@ -1,0 +1,37 @@
+from typing import List
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp
+
+from .locale import set_locale
+
+
+class LocaleMiddleware(BaseHTTPMiddleware):
+    def __init__(
+        self,
+        app: ASGIApp,
+        languages: List[str],
+        default_language: str,
+    ) -> None:
+        super().__init__(app)
+        self._languages = languages
+        self._default_language = default_language
+
+    def _get_language_from_path(self, path: str) -> str:
+        for language in self._languages:
+            language_prefix = f"/{language}"
+            if path.startswith(language_prefix):
+                return language
+
+        return self._default_language
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        language = self._get_language_from_path(request.url.path)
+        assert language in self._languages
+        set_locale(language)
+        request.scope["language"] = language  # For usage by routes.
+        return await call_next(request)

--- a/server/i18n/routing.py
+++ b/server/i18n/routing.py
@@ -1,0 +1,25 @@
+from typing import Tuple
+
+from starlette.datastructures import Scope
+from starlette.routing import Match, Route
+
+
+class LocaleRoute(Route):
+    def matches(self, scope: Scope) -> Tuple[Match, Scope]:
+        if scope["type"] != "http":
+            # Eg hot-reload WebSocket.
+            return super().matches(scope)
+
+        path = scope["path"]
+        assert "language" in scope, "LocaleMiddleware is not installed"
+        language = scope["language"]
+
+        # Let route match regardless of language prefix.
+        # Example: a request to "/fr/blog" should match `LocaleRoute("/blog")`.
+        # NOTE: Unknown languages are passed through and result
+        # in a "no-match", as expected.
+        language_prefix = f"/{language}"
+        if path.startswith(language_prefix):
+            scope["path"] = path[len(language_prefix) :]
+
+        return super().matches(scope)

--- a/server/i18n/routing.py
+++ b/server/i18n/routing.py
@@ -6,7 +6,7 @@ from starlette.routing import Match, Route
 
 class LocaleRoute(Route):
     def matches(self, scope: Scope) -> Tuple[Match, Scope]:
-        if scope["type"] != "http":
+        if scope["type"] != "http":  # pragma: no cover
             # Eg hot-reload WebSocket.
             return super().matches(scope)
 

--- a/server/middleware.py
+++ b/server/middleware.py
@@ -7,6 +7,7 @@ from starlette.responses import Response
 from starlette.types import ASGIApp
 
 from . import legacy, settings
+from .i18n.middleware import LocaleMiddleware
 
 middleware = [
     # NOTE: Middleware executes from top to bottom.
@@ -14,6 +15,11 @@ middleware = [
         legacy.LegacyRedirectMiddleware,
         url_mapping=settings.LEGACY_URL_MAPPING,
         root_path="/blog",
+    ),
+    Middleware(
+        LocaleMiddleware,
+        languages=settings.LANGUAGES,
+        default_language=settings.DEFAULT_LANGUAGE,
     ),
 ]
 

--- a/server/routes.py
+++ b/server/routes.py
@@ -1,6 +1,7 @@
 from starlette.routing import Host, Mount, Route, WebSocketRoute
 
 from . import legacy, middleware, resources, settings, views
+from .i18n.routing import LocaleRoute
 from .reload import hotreload
 from .sitemap import sitemap
 
@@ -20,7 +21,7 @@ routes = [
         app=legacy.DomainRedirect("florimond.dev", root_path="/blog"),
         name="legacy:blog_dot_dev",
     ),
-    Route("/", views.home),
+    LocaleRoute("/", views.home),
     Route("/error/", views.error),
     Route("/blog/", views.legacy_blog_home, name="legacy:blog_home"),
     Route("/blog/{permalink:path}/", views.RenderPage, name="page"),

--- a/server/settings.py
+++ b/server/settings.py
@@ -27,6 +27,12 @@ STATIC_ROOT = "/static"
 STATIC_DIR = HERE / "static"
 TEMPLATES_DIR = HERE / "templates"
 
+LOCALE_DIR = HERE.parent / "locale"
+LOCALE_DOMAIN = "messages"
+LOCALE_TRANSLATIONS = ["fr_FR"]
+LANGUAGES = ["en", "fr"]
+DEFAULT_LANGUAGE = "en"
+
 EXTRA_CONTENT_DIRS = config(
     "EXTRA_CONTENT_DIRS",
     cast=lambda v: [pathlib.Path(item) for item in CommaSeparatedStrings(v)],

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ ignore_missing_imports = True
 [tool:isort]
 profile = black
 known_first_party = server
-known_third_party = PIL,aiofiles,arel,asgi_lifespan,asgi_sitemaps,black,exdown,frontmatter,httpx,markdown,pytest,starlette
+known_third_party = PIL,aiofiles,arel,asgi_lifespan,asgi_sitemaps,babel,black,exdown,frontmatter,httpx,markdown,pytest,starlette
 
 [tool:pytest]
 addopts = tests --cov=server --cov-report=term-missing -rxXs

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,0 +1,20 @@
+import httpx
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_i18n_home(client: httpx.AsyncClient) -> None:
+    url = "http://florimond.dev/fr/"
+    resp = await client.get(url, allow_redirects=False)
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+
+    assert "Tutoriels" in resp.text  # Navbar
+
+
+@pytest.mark.asyncio
+async def test_i18n_unknown_language(client: httpx.AsyncClient) -> None:
+    url = "http://florimond.dev/de/"
+    resp = await client.get(url, allow_redirects=False)
+    assert resp.status_code == 404
+    assert "text/html" in resp.headers["content-type"]


### PR DESCRIPTION
Lower-touch alternative to #191 

## Description
Add minimal infrastructure for translations.

Essentially adds a `/fr/` page which returns the home page, with the navbar translated in French.

## Motivation
I'd like to start publishing content in French.

## Details
This required:

* `locale.py`, `gettext.py`, etc: gettext translations setup, with a `ContextVar` storing the task-current locale.
* `LocaleMiddleware`:  detects any locale in the URL (eg `/fr/...` -> `fr`), sets it for `gettext`, and saves it as `request.scope["locale"]`.
* `LocaleRoute`: a route class that ignores the locale prefix when matching. Usage: `LocaleRoute("/page", ...)` -> will match `/page` (default language), or `/fr/page` (French translation).

## Notes
This is purely additive. The `/fr/` page is not linked to from anywhere yet (can only be accessed directly).

Future work includes:

* Default locale prefix: `/` and `/blog/...` should redirect to `/en/` and `/en/blog/...`.
* Locale-consistent URLs: when on `/fr/`, all links to other pages should be `/fr/...` as well.

At least this gets a lot of the boilerplate out of the way.