### PR TITLE
Fix link to category from article page

### DIFF
--- a/server/templates/components/pages/article_meta.jinja
+++ b/server/templates/components/pages/article_meta.jinja
@@ -6,7 +6,7 @@
     {{ page.frontmatter.date | dateformat }}
     |
     in
-    <a href="{{ url_for('page', permalink='/category/' + page.frontmatter.category) }}">
+    <a href="{{ url_for('page', permalink='category/' + page.frontmatter.category) }}">
       {{ page.frontmatter.category | category_label }}
     </a>
   </div>


### PR DESCRIPTION
Category link from an article page would be eg `/blog//category/essays` and return 404.

See: https://florimond.dev/blog/articles/2021/04/google-floc/ and click "Essays".