### PR TITLE
Add support for internationalized posts

### DIFF
--- a/locale/base.pot
+++ b/locale/base.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-04-22 16:27+0200\n"
+"POT-Creation-Date: 2021-04-29 21:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,15 +17,19 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.0\n"
 
-#: server/content.py:128
+#: server/content.py:131
 msgid "Tutorials"
 msgstr ""
 
-#: server/content.py:129
+#: server/content.py:132
 msgid "Essays"
 msgstr ""
 
-#: server/content.py:130
+#: server/content.py:133
 msgid "Retrospectives"
+msgstr ""
+
+#: server/templates/components/pages/post_list.jinja:10
+msgid "No posts yet."
 msgstr ""
 

--- a/locale/fr_FR/LC_MESSAGES/messages.po
+++ b/locale/fr_FR/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-04-22 16:27+0200\n"
+"POT-Creation-Date: 2021-04-29 21:18+0200\n"
 "PO-Revision-Date: 2021-04-22 16:27+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr_FR\n"
@@ -18,15 +18,19 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.9.0\n"
 
-#: server/content.py:128
+#: server/content.py:131
 msgid "Tutorials"
 msgstr "Tutoriels"
 
-#: server/content.py:129
+#: server/content.py:132
 msgid "Essays"
 msgstr "Écrits"
 
-#: server/content.py:130
+#: server/content.py:133
 msgid "Retrospectives"
 msgstr "Rétrospectives"
+
+#: server/templates/components/pages/post_list.jinja:10
+msgid "No posts yet."
+msgstr "Pas encore de billets."
 

--- a/server/i18n/__init__.py
+++ b/server/i18n/__init__.py
@@ -1,8 +1,10 @@
 from .gettext import gettext_lazy
+from .jinja2 import setup_jinja2
 from .locale import get_locale, set_locale, using_locale
 
 __all__ = [
     "gettext_lazy",
+    "setup_jinja2",
     "get_locale",
     "set_locale",
     "using_locale",

--- a/server/i18n/__init__.py
+++ b/server/i18n/__init__.py
@@ -1,5 +1,9 @@
 from .gettext import gettext_lazy
+from .locale import get_locale, set_locale, using_locale
 
 __all__ = [
     "gettext_lazy",
+    "get_locale",
+    "set_locale",
+    "using_locale",
 ]

--- a/server/i18n/gettext.py
+++ b/server/i18n/gettext.py
@@ -8,5 +8,9 @@ def gettext(message: str) -> str:
     return locale.gettext(message)
 
 
+def ngettext(singular: str, plural: str, count: int) -> str:
+    raise NotImplementedError  # pragma: no cover
+
+
 def gettext_lazy(string: str) -> LazyProxy:
     return LazyProxy(gettext, string, enable_cache=False)

--- a/server/i18n/jinja2.py
+++ b/server/i18n/jinja2.py
@@ -1,0 +1,15 @@
+from starlette.templating import Jinja2Templates
+
+from .gettext import gettext, ngettext
+from .locale import get_locale
+
+
+def i18n_path(path: str) -> str:
+    language = get_locale().language
+    return f"/{language}{path}"
+
+
+def setup_jinja2(templates: Jinja2Templates) -> None:
+    templates.env.add_extension("jinja2.ext.i18n")
+    templates.env.install_gettext_callables(gettext, ngettext, newstyle=True)
+    templates.env.globals["i18n_path"] = i18n_path

--- a/server/models.py
+++ b/server/models.py
@@ -1,6 +1,8 @@
 import dataclasses
 import typing
 
+from .i18n import get_locale
+
 
 @dataclasses.dataclass(frozen=True)
 class ContentItem:
@@ -30,12 +32,18 @@ class Page:
     content: str = ""
 
     @property
+    def language(self) -> str:
+        # '/en/posts/...' -> 'en'
+        parts = self.permalink.split("/")
+        return parts[1]
+
+    @property
     def is_post(self) -> bool:
-        return self.permalink.startswith("/en/posts/")
+        return "/posts/" in self.permalink
 
     @property
     def is_category(self) -> bool:
-        return self.permalink.startswith("/category/")
+        return "/category/" in self.permalink
 
 
 class Index:
@@ -44,7 +52,15 @@ class Index:
     """
 
     def __init__(self) -> None:
-        self.pages: typing.List[Page] = []
+        self._pages: typing.Dict[str, typing.List[Page]] = {}
+
+    def get_i18n_aware_pages(self, language: str = None) -> typing.List[Page]:
+        if language is None:
+            language = get_locale().language
+        return self._pages[language]
+
+    def set_pages(self, pages: typing.Dict[str, typing.List[Page]]) -> None:
+        self._pages = pages
 
     def get_post_pages(
         self,
@@ -54,8 +70,9 @@ class Index:
         limit: int = None,
     ) -> typing.List[Page]:
         posts = []
+        pages = self.get_i18n_aware_pages()
 
-        for page in self.pages:
+        for page in pages:
             if not page.is_post:
                 continue
             if tag is not None and tag not in page.frontmatter.tags:
@@ -71,7 +88,8 @@ class Index:
         return posts[:limit]
 
     def get_category_pages(self) -> typing.List[Page]:
-        return [page for page in self.pages if page.is_category]
+        pages = self.get_i18n_aware_pages()
+        return [page for page in pages if page.is_category]
 
 
 class MetaTag:

--- a/server/resources.py
+++ b/server/resources.py
@@ -6,6 +6,7 @@ from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 
 from . import settings
+from .i18n import get_locale
 from .models import Index
 from .reload import hotreload
 
@@ -28,10 +29,16 @@ def category_label(value: str) -> str:
     return get_category_label(value)
 
 
+def i18n_path(path: str) -> str:
+    language = get_locale().language
+    return f"/{language}{path}"
+
+
 templates.env.globals["now"] = dt.datetime.now
 templates.env.globals["raise"] = raise_server_error
 templates.env.globals["settings"] = settings
 templates.env.globals["hotreload"] = hotreload
+templates.env.globals["i18n_path"] = i18n_path
 templates.env.filters["dateformat"] = dateformat
 templates.env.filters["category_label"] = category_label
 

--- a/server/resources.py
+++ b/server/resources.py
@@ -5,8 +5,7 @@ from starlette.exceptions import HTTPException
 from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 
-from . import settings
-from .i18n import get_locale
+from . import i18n, settings
 from .models import Index
 from .reload import hotreload
 
@@ -29,16 +28,12 @@ def category_label(value: str) -> str:
     return get_category_label(value)
 
 
-def i18n_path(path: str) -> str:
-    language = get_locale().language
-    return f"/{language}{path}"
-
+i18n.setup_jinja2(templates)
 
 templates.env.globals["now"] = dt.datetime.now
 templates.env.globals["raise"] = raise_server_error
 templates.env.globals["settings"] = settings
 templates.env.globals["hotreload"] = hotreload
-templates.env.globals["i18n_path"] = i18n_path
 templates.env.filters["dateformat"] = dateformat
 templates.env.filters["category_label"] = category_label
 

--- a/server/sitemap.py
+++ b/server/sitemap.py
@@ -2,6 +2,7 @@ from typing import List
 
 import asgi_sitemaps
 
+from . import settings
 from .models import Page
 from .resources import index
 
@@ -23,10 +24,13 @@ class PagesSitemap(asgi_sitemaps.Sitemap):
     protocol = "https"
 
     def items(self) -> List[Page]:
-        return index.pages
+        pages = []
+        for language in settings.LANGUAGES:
+            pages.extend(index.get_i18n_aware_pages(language))
+        return pages
 
     def location(self, page: Page) -> str:
-        return f"/blog{page.permalink}"
+        return page.permalink
 
     def changefreq(self, path: str) -> str:
         return "weekly"

--- a/server/templates/components/pages/post_list.jinja
+++ b/server/templates/components/pages/post_list.jinja
@@ -6,8 +6,8 @@
     {{ PostListItem(page) }}
   {%- else -%}
 </ul>
-  <p>
-    No posts yet.
+  <p class="text-center">
+    {{ _('No posts yet.') }}
   </p>
 {%- endfor %}
 {% endmacro %}

--- a/server/templates/components/pages/post_meta.jinja
+++ b/server/templates/components/pages/post_meta.jinja
@@ -6,7 +6,7 @@
     {{ page.frontmatter.date | dateformat }}
     |
     in
-    <a href="{{ url_for('page', permalink='category/' + page.frontmatter.category) }}">
+    <a href="{{ url_for('page', permalink=i18n_path('/category/' + page.frontmatter.category).lstrip('/')) }}">
       {{ page.frontmatter.category | category_label }}
     </a>
   </div>

--- a/server/templates/components/pages/tag_list.jinja
+++ b/server/templates/components/pages/tag_list.jinja
@@ -4,7 +4,7 @@
     🔖
   </span>
   {% for tag in tags %}
-  <a class="c-tag-list-item" href="{{ url_for('page', permalink='tag/' + tag) }}">
+  <a class="c-tag-list-item" href="{{ url_for('page', permalink=i18n_path('/tag/' + tag).lstrip('/')) }}">
     {{ tag }}
   </a>
   {% endfor %}

--- a/server/views.py
+++ b/server/views.py
@@ -26,7 +26,7 @@ class RenderPage(HTTPEndpoint):
     async def get(self, request: Request) -> Response:
         permalink = "/" + request.path_params["permalink"]
 
-        for page in resources.index.pages:
+        for page in resources.index.get_i18n_aware_pages():
             if page.permalink == permalink:
                 break
         else:

--- a/tests/drafts/fr/posts/2021/04/test-brouillon.md
+++ b/tests/drafts/fr/posts/2021/04/test-brouillon.md
@@ -1,0 +1,10 @@
+---
+title: "Test"
+description: "Un brouillon de test."
+date: "2021-04-29"
+category: tutorials
+tags:
+  - test
+---
+
+Un brouillon de test.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -34,7 +34,7 @@ async def test_article_no_trailing_slash(client: httpx.AsyncClient) -> None:
 
 
 async def test_tag(client: httpx.AsyncClient) -> None:
-    url = "http://florimond.dev/tag/python/"
+    url = "http://florimond.dev/en/tag/python/"
     resp = await client.get(url, allow_redirects=False)
     assert resp.status_code == 200, resp.url
     assert "text/html" in resp.headers["content-type"]
@@ -58,7 +58,7 @@ def test_known_categories() -> None:
 
 @pytest.mark.parametrize("category", KNOWN_CATEGORIES)
 async def test_category(client: httpx.AsyncClient, category: str) -> None:
-    url = f"http://florimond.dev/category/{category}/"
+    url = f"http://florimond.dev/en/category/{category}/"
     resp = await client.get(url, allow_redirects=False)
     assert resp.status_code == 200, resp.url
     assert "text/html" in resp.headers["content-type"]

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -9,12 +9,14 @@ from server.models import ContentItem
 
 def test_build_pages_empty() -> None:
     pages = build_pages([])
-    assert pages == []
+    assert pages == {"en": [], "fr": []}
 
 
 def test_build_pages() -> None:
     title = "Readability Counts"
+    title_fr = "La Lisibilité Compte"
     description = "How readability impacts software development."
+    description_fr = "Comment la lisibilité impacte le développement logiciel."
     date = "2000-01-01"
     category = "essays"
     image = "/static/img/articles/example.jpg"
@@ -35,25 +37,44 @@ def test_build_pages() -> None:
                 You should *really* care about readability.
                 """
             ),
-            location="posts/readability-counts.md",
-        )
+            location="en/posts/readability-counts.md",
+        ),
+        ContentItem(
+            content=dedent(
+                f"""
+                ---
+                title: "{title_fr}"
+                description: "{description_fr}"
+                date: "{date}"
+                category: {category}
+                tags:
+                - python
+                image: "{image}"
+                ---
+                Vous devriez *vraiment* prendre en compte la lisibilité.
+                """
+            ),
+            location="fr/posts/lisibilite.md",
+        ),
     ]
 
     pages = build_pages(items)
+    assert set(pages) == {"en", "fr"}
 
-    assert len(pages) == 3
-    readability_counts, python, essays = pages
+    assert len(pages["en"]) == 3
+    readability_counts, python, essays = pages["en"]
 
-    assert readability_counts.permalink == "/posts/readability-counts"
+    assert readability_counts.permalink == "/en/posts/readability-counts"
     assert readability_counts.frontmatter.title == title
     assert readability_counts.frontmatter.description == description
     assert readability_counts.frontmatter.date == date
     assert readability_counts.frontmatter.category == category
     assert readability_counts.frontmatter.tags == ["python"]
     assert readability_counts.frontmatter.image == image
+    assert readability_counts.language == "en"
 
     meta = [str(tag) for tag in readability_counts.meta]
-    url = "https://florimond.dev/posts/readability-counts/"
+    url = "https://florimond.dev/en/posts/readability-counts/"
     assert '<meta name="twitter:card" content="summary_large_image">' in meta
     assert f'<meta name="twitter:title" content="{title}">' in meta
     assert f'<meta name="twitter:description" content="{description}">' in meta
@@ -65,15 +86,16 @@ def test_build_pages() -> None:
         "<p>You should <em>really</em> care about readability.</p>"
     )
 
-    assert python.permalink == "/tag/python"
+    assert python.permalink == "/en/tag/python"
     assert python.frontmatter.title
     assert python.frontmatter.description
     assert python.frontmatter.date is None
     assert python.frontmatter.tags == []
     assert python.frontmatter.tag == "python"
+    assert python.language == "en"
 
     meta = [str(tag) for tag in python.meta]
-    url = "https://florimond.dev/tag/python/"
+    url = "https://florimond.dev/en/tag/python/"
     assert '<meta name="twitter:card" content="summary_large_image">' in meta
     assert f'<meta name="twitter:title" content="{python.frontmatter.title}">' in meta
     assert (
@@ -81,15 +103,78 @@ def test_build_pages() -> None:
     ) in meta
     assert f'<meta name="twitter:url" content="{url}">' in meta
 
-    assert essays.permalink == "/category/essays"
+    assert essays.permalink == "/en/category/essays"
     assert "Essays" in essays.frontmatter.title
     assert essays.frontmatter.description
     assert essays.frontmatter.date is None
     assert essays.frontmatter.category == category
     assert essays.frontmatter.tags == []
+    assert essays.language == "en"
 
     meta = [str(tag) for tag in essays.meta]
-    url = "https://florimond.dev/category/essays/"
+    url = "https://florimond.dev/en/category/essays/"
+    assert '<meta name="twitter:card" content="summary_large_image">' in meta
+    assert f'<meta name="twitter:title" content="{essays.frontmatter.title}">' in meta
+    assert (
+        f'<meta name="twitter:description" content="{essays.frontmatter.description}">'
+        in meta
+    )
+    assert f'<meta name="twitter:url" content="{url}">' in meta
+
+    # FR
+
+    assert len(pages["fr"]) == 3
+    lisibilite, python, essays = pages["fr"]
+
+    assert lisibilite.permalink == "/fr/posts/lisibilite"
+    assert lisibilite.frontmatter.title == title_fr
+    assert lisibilite.frontmatter.description == description_fr
+    assert lisibilite.frontmatter.date == date
+    assert lisibilite.frontmatter.category == category
+    assert lisibilite.frontmatter.tags == ["python"]
+    assert lisibilite.frontmatter.image == image
+    assert lisibilite.language == "fr"
+
+    meta = [str(tag) for tag in lisibilite.meta]
+    url = "https://florimond.dev/fr/posts/lisibilite/"
+    assert '<meta name="twitter:card" content="summary_large_image">' in meta
+    assert f'<meta name="twitter:title" content="{title_fr}">' in meta
+    assert f'<meta name="twitter:description" content="{description_fr}">' in meta
+    assert f'<meta name="twitter:url" content="{url}">' in meta
+    assert f'<meta name="twitter:image" content="https://florimond.dev{image}">' in meta
+    assert '<meta property="article:tag" content="python">' in meta
+
+    assert lisibilite.html == (
+        "<p>Vous devriez <em>vraiment</em> prendre en compte la lisibilité.</p>"
+    )
+
+    assert python.permalink == "/fr/tag/python"
+    assert python.frontmatter.title
+    assert python.frontmatter.description
+    assert python.frontmatter.date is None
+    assert python.frontmatter.tags == []
+    assert python.frontmatter.tag == "python"
+    assert python.language == "fr"
+
+    meta = [str(tag) for tag in python.meta]
+    url = "https://florimond.dev/fr/tag/python/"
+    assert '<meta name="twitter:card" content="summary_large_image">' in meta
+    assert f'<meta name="twitter:title" content="{python.frontmatter.title}">' in meta
+    assert (
+        f'<meta name="twitter:description" content="{python.frontmatter.description}">'
+    ) in meta
+    assert f'<meta name="twitter:url" content="{url}">' in meta
+
+    assert essays.permalink == "/fr/category/essays"
+    assert "Écrits" in essays.frontmatter.title
+    assert essays.frontmatter.description
+    assert essays.frontmatter.date is None
+    assert essays.frontmatter.category == category
+    assert essays.frontmatter.tags == []
+    assert essays.language == "fr"
+
+    meta = [str(tag) for tag in essays.meta]
+    url = "https://florimond.dev/fr/category/essays/"
     assert '<meta name="twitter:card" content="summary_large_image">' in meta
     assert f'<meta name="twitter:title" content="{essays.frontmatter.title}">' in meta
     assert (
@@ -119,8 +204,8 @@ def test_image_auto_thumbnail(image: str, image_thumbnail: Optional[str]) -> Non
             ---
             """
         ),
-        location="posts/test.md",
+        location="en/posts/test.md",
     )
 
-    (page,) = build_pages([item])
+    (page,) = build_pages([item])["en"]
     assert page.frontmatter.image_thumbnail == image_thumbnail

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,6 +1,8 @@
 import httpx
 import pytest
 
+from server.i18n import get_locale, set_locale
+
 
 @pytest.mark.asyncio
 async def test_i18n_home(client: httpx.AsyncClient) -> None:
@@ -18,3 +20,14 @@ async def test_i18n_unknown_language(client: httpx.AsyncClient) -> None:
     resp = await client.get(url, allow_redirects=False)
     assert resp.status_code == 404
     assert "text/html" in resp.headers["content-type"]
+
+
+@pytest.mark.asyncio
+async def test_i18n_locale() -> None:
+    locale = get_locale()
+    assert locale.language == "en"
+    assert repr(locale) == "Locale('en')"
+
+    set_locale("fr")
+    locale = get_locale()
+    assert repr(locale) == "Locale('fr')"

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -16,7 +16,7 @@ async def test_images(client: httpx.AsyncClient) -> None:
     All images linked in articles must exist and be local files.
     """
     remote_urls = []
-    for page in index.pages:
+    for page in index.get_i18n_aware_pages():
         url = page.frontmatter.image
         if url is not None and url.startswith("http"):
             remote_urls.append(url)


### PR DESCRIPTION
New spin of #191 

* Add support for loading blog posts from `content/en`, `content/fr`, etc, with tracking of each language.
* Only show posts for the current language (as determined by the URL).

This is completely additive. Right now the URL https://florimond.dev/fr/ would show a home page with no blog posts ("Pas de billets").

Quite big — let's see if I can break this down…