### PR TITLE
Migrate category and tag pages to /en/ namespace

### DIFF
--- a/server/content.py
+++ b/server/content.py
@@ -13,7 +13,8 @@ from .utils import to_production_url
 
 async def load_content() -> None:
     items = [item async for item in load_content_items()]
-    resources.index.pages = build_pages(items)
+    pages = build_pages(items)
+    resources.index.set_pages(pages)
 
 
 def iter_content_paths() -> Iterator[Tuple[Path, Path]]:
@@ -34,26 +35,28 @@ async def load_content_items() -> AsyncIterator[ContentItem]:
             )
 
 
-def build_pages(items: List[ContentItem]) -> List[Page]:
-    pages = []
+def build_pages(items: List[ContentItem]) -> Dict[str, List[Page]]:
+    pages: Dict[str, List[Page]] = {language: [] for language in settings.LANGUAGES}
 
     for page in _build_content_pages(items):
-        pages.append(page)
+        pages["en"].append(page)
 
-    unique_tags = {tag for page in pages for tag in page.frontmatter.tags}
+    for language in pages:
+        unique_tags = {tag for page in pages[language] for tag in page.frontmatter.tags}
 
-    for page in _generate_tag_pages(unique_tags):
-        pages.append(page)
+        for page in _generate_tag_pages(unique_tags, language=language):
+            pages[language].append(page)
 
-    unique_categories = sorted(
-        {
-            page.frontmatter.category
-            for page in pages
-            if page.frontmatter.category is not None
-        },
-        key=list(_CATEGORY_LABELS).index,
-    )
-    pages.extend(_generate_category_pages(unique_categories))
+        unique_categories = sorted(
+            {
+                page.frontmatter.category
+                for page in pages[language]
+                if page.frontmatter.category is not None
+            },
+            key=list(_CATEGORY_LABELS).index,
+        )
+        category_pages = _generate_category_pages(unique_categories, language=language)
+        pages[language].extend(category_pages)
 
     return pages
 
@@ -111,14 +114,14 @@ def _append_filename(filename: str, suffix: str) -> str:
     return str(path.with_name(name))
 
 
-def _generate_tag_pages(tags: Iterable[str]) -> Iterator[Page]:
+def _generate_tag_pages(tags: Iterable[str], *, language: str) -> Iterator[Page]:
     for tag in tags:
         frontmatter = Frontmatter(
             title=f"{tag.capitalize()} - {settings.SITE_TITLE}",
             description=f"Posts about #{tag}",
             tag=tag,
         )
-        permalink = f"/tag/{tag}"
+        permalink = f"/{language}/tag/{tag}"
         meta = _build_meta(permalink, frontmatter)
 
         yield Page(permalink=permalink, frontmatter=frontmatter, meta=meta)
@@ -140,7 +143,9 @@ def get_category_label(value: str) -> str:
         )
 
 
-def _generate_category_pages(categories: Iterable[str]) -> Iterator[Page]:
+def _generate_category_pages(
+    categories: Iterable[str], *, language: str
+) -> Iterator[Page]:
     for category in categories:
         label = get_category_label(category)
         frontmatter = Frontmatter(
@@ -148,7 +153,7 @@ def _generate_category_pages(categories: Iterable[str]) -> Iterator[Page]:
             description=label,
             category=category,
         )
-        permalink = f"/category/{category}"
+        permalink = f"/{language}/category/{category}"
         meta = _build_meta(permalink, frontmatter)
 
         yield Page(permalink=permalink, frontmatter=frontmatter, meta=meta)

--- a/server/i18n/__init__.py
+++ b/server/i18n/__init__.py
@@ -1,5 +1,10 @@
 from .gettext import gettext_lazy
+from .jinja2 import setup_jinja2
+from .locale import get_locale, set_locale
 
 __all__ = [
     "gettext_lazy",
+    "setup_jinja2",
+    "get_locale",
+    "set_locale",
 ]

--- a/server/i18n/jinja2.py
+++ b/server/i18n/jinja2.py
@@ -1,0 +1,18 @@
+from starlette.templating import Jinja2Templates
+
+from .gettext import gettext
+from .locale import get_locale
+
+
+def i18n_path(path: str) -> str:
+    language = get_locale().language
+    return f"/{language}{path}"
+
+
+def setup_jinja2(templates: Jinja2Templates) -> None:
+    def ngettext(s, p, c):  # type: ignore
+        raise NotImplementedError  # pragma: no cover
+
+    templates.env.add_extension("jinja2.ext.i18n")
+    templates.env.install_gettext_callables(gettext, ngettext, newstyle=True)
+    templates.env.globals["i18n_path"] = i18n_path

--- a/server/i18n/locale.py
+++ b/server/i18n/locale.py
@@ -24,13 +24,21 @@ class Locale:
     A convenience wrapper around a `gettext` translations object.
     """
 
-    def __init__(self, translations: Translations = None) -> None:
+    def __init__(self, language: str, translations: Translations = None) -> None:
+        self._language = language
         self._translations = (
             translations if translations is not None else NullTranslations()
         )
 
+    @property
+    def language(self) -> str:
+        return self._language
+
     def gettext(self, message: str) -> str:
         return self._translations.ugettext(message)
+
+    def __repr__(self) -> str:
+        return f"<Locale({self._language!r})>"
 
 
 def build_locale(code: str) -> Locale:
@@ -40,7 +48,7 @@ def build_locale(code: str) -> Locale:
     if locale is None:  # pragma: no cover
         raise RuntimeError(f"Unsupported locale: {code!r}")
 
-    return Locale(translations=_translations.get(str(locale)))
+    return Locale(language=locale.language, translations=_translations.get(str(locale)))
 
 
 _locale_context: ContextVar["Locale"] = ContextVar(

--- a/server/models.py
+++ b/server/models.py
@@ -35,7 +35,7 @@ class Page:
 
     @property
     def is_category(self) -> bool:
-        return self.permalink.startswith("/category/")
+        return self.permalink.startswith("/en/category/")
 
 
 class Index:
@@ -44,7 +44,13 @@ class Index:
     """
 
     def __init__(self) -> None:
-        self.pages: typing.List[Page] = []
+        self._pages: typing.Dict[str, typing.List[Page]] = {}
+
+    def set_pages(self, pages: typing.Dict[str, typing.List[Page]]) -> None:
+        self._pages = pages
+
+    def get_pages(self) -> typing.List[Page]:
+        return self._pages["en"]
 
     def get_post_pages(
         self,
@@ -55,7 +61,7 @@ class Index:
     ) -> typing.List[Page]:
         posts = []
 
-        for page in self.pages:
+        for page in self.get_pages():
             if not page.is_post:
                 continue
             if tag is not None and tag not in page.frontmatter.tags:
@@ -71,7 +77,7 @@ class Index:
         return posts[:limit]
 
     def get_category_pages(self) -> typing.List[Page]:
-        return [page for page in self.pages if page.is_category]
+        return [page for page in self.get_pages() if page.is_category]
 
 
 class MetaTag:

--- a/server/resources.py
+++ b/server/resources.py
@@ -5,7 +5,7 @@ from starlette.exceptions import HTTPException
 from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
 
-from . import settings
+from . import i18n, settings
 from .models import Index
 from .reload import hotreload
 
@@ -27,6 +27,8 @@ def category_label(value: str) -> str:
 
     return get_category_label(value)
 
+
+i18n.setup_jinja2(templates)
 
 templates.env.globals["now"] = dt.datetime.now
 templates.env.globals["raise"] = raise_server_error

--- a/server/sitemap.py
+++ b/server/sitemap.py
@@ -23,7 +23,7 @@ class PagesSitemap(asgi_sitemaps.Sitemap):
     protocol = "https"
 
     def items(self) -> List[Page]:
-        return index.pages
+        return index.get_pages()
 
     def location(self, page: Page) -> str:
         return f"/blog{page.permalink}"

--- a/server/templates/components/pages/post_meta.jinja
+++ b/server/templates/components/pages/post_meta.jinja
@@ -6,7 +6,7 @@
     {{ page.frontmatter.date | dateformat }}
     |
     in
-    <a href="{{ url_for('page', permalink='category/' + page.frontmatter.category) }}">
+    <a href="{{ url_for('page', permalink=i18n_path('/category/' + page.frontmatter.category).lstrip('/')) }}">
       {{ page.frontmatter.category | category_label }}
     </a>
   </div>

--- a/server/templates/components/pages/tag_list.jinja
+++ b/server/templates/components/pages/tag_list.jinja
@@ -4,7 +4,7 @@
     🔖
   </span>
   {% for tag in tags %}
-  <a class="c-tag-list-item" href="{{ url_for('page', permalink='tag/' + tag) }}">
+  <a class="c-tag-list-item" href="{{ url_for('page', permalink=i18n_path('/tag/' + tag).lstrip('/')) }}">
     {{ tag }}
   </a>
   {% endfor %}

--- a/server/views.py
+++ b/server/views.py
@@ -26,7 +26,7 @@ class RenderPage(HTTPEndpoint):
     async def get(self, request: Request) -> Response:
         permalink = "/" + request.path_params["permalink"]
 
-        for page in resources.index.pages:
+        for page in resources.index.get_pages():
             if page.permalink == permalink:
                 break
         else:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -34,7 +34,7 @@ async def test_article_no_trailing_slash(client: httpx.AsyncClient) -> None:
 
 
 async def test_tag(client: httpx.AsyncClient) -> None:
-    url = "http://florimond.dev/tag/python/"
+    url = "http://florimond.dev/en/tag/python/"
     resp = await client.get(url, allow_redirects=False)
     assert resp.status_code == 200, resp.url
     assert "text/html" in resp.headers["content-type"]
@@ -58,7 +58,7 @@ def test_known_categories() -> None:
 
 @pytest.mark.parametrize("category", KNOWN_CATEGORIES)
 async def test_category(client: httpx.AsyncClient, category: str) -> None:
-    url = f"http://florimond.dev/category/{category}/"
+    url = f"http://florimond.dev/en/category/{category}/"
     resp = await client.get(url, allow_redirects=False)
     assert resp.status_code == 200, resp.url
     assert "text/html" in resp.headers["content-type"]

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -9,7 +9,7 @@ from server.models import ContentItem
 
 def test_build_pages_empty() -> None:
     pages = build_pages([])
-    assert pages == []
+    assert pages == {"en": [], "fr": []}
 
 
 def test_build_pages() -> None:
@@ -40,9 +40,9 @@ def test_build_pages() -> None:
     ]
 
     pages = build_pages(items)
+    assert set(pages) == {"en", "fr"}
 
-    assert len(pages) == 3
-    readability_counts, python, essays = pages
+    readability_counts, python, essays = pages["en"]
 
     assert readability_counts.permalink == "/posts/readability-counts"
     assert readability_counts.frontmatter.title == title
@@ -65,7 +65,7 @@ def test_build_pages() -> None:
         "<p>You should <em>really</em> care about readability.</p>"
     )
 
-    assert python.permalink == "/tag/python"
+    assert python.permalink == "/en/tag/python"
     assert python.frontmatter.title
     assert python.frontmatter.description
     assert python.frontmatter.date is None
@@ -73,7 +73,7 @@ def test_build_pages() -> None:
     assert python.frontmatter.tag == "python"
 
     meta = [str(tag) for tag in python.meta]
-    url = "https://florimond.dev/tag/python/"
+    url = "https://florimond.dev/en/tag/python/"
     assert '<meta name="twitter:card" content="summary_large_image">' in meta
     assert f'<meta name="twitter:title" content="{python.frontmatter.title}">' in meta
     assert (
@@ -81,7 +81,7 @@ def test_build_pages() -> None:
     ) in meta
     assert f'<meta name="twitter:url" content="{url}">' in meta
 
-    assert essays.permalink == "/category/essays"
+    assert essays.permalink == "/en/category/essays"
     assert "Essays" in essays.frontmatter.title
     assert essays.frontmatter.description
     assert essays.frontmatter.date is None
@@ -89,7 +89,7 @@ def test_build_pages() -> None:
     assert essays.frontmatter.tags == []
 
     meta = [str(tag) for tag in essays.meta]
-    url = "https://florimond.dev/category/essays/"
+    url = "https://florimond.dev/en/category/essays/"
     assert '<meta name="twitter:card" content="summary_large_image">' in meta
     assert f'<meta name="twitter:title" content="{essays.frontmatter.title}">' in meta
     assert (
@@ -122,5 +122,5 @@ def test_image_auto_thumbnail(image: str, image_thumbnail: Optional[str]) -> Non
         location="posts/test.md",
     )
 
-    (page,) = build_pages([item])
+    (page,) = build_pages([item])["en"]
     assert page.frontmatter.image_thumbnail == image_thumbnail

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -1,6 +1,8 @@
 import httpx
 import pytest
 
+from server.i18n import get_locale, set_locale
+
 
 @pytest.mark.asyncio
 async def test_i18n_home(client: httpx.AsyncClient) -> None:
@@ -18,3 +20,15 @@ async def test_i18n_unknown_language(client: httpx.AsyncClient) -> None:
     resp = await client.get(url, allow_redirects=False)
     assert resp.status_code == 404
     assert "text/html" in resp.headers["content-type"]
+
+
+@pytest.mark.asyncio
+async def test_i18n_locale() -> None:
+    locale = get_locale()
+    assert locale.language == "en"
+    assert repr(locale) == "<Locale('en')>"
+
+    set_locale("fr")
+    locale = get_locale()
+    assert locale.language == "fr"
+    assert repr(locale) == "<Locale('fr')>"

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -16,7 +16,7 @@ async def test_images(client: httpx.AsyncClient) -> None:
     All images linked in articles must exist and be local files.
     """
     remote_urls = []
-    for page in index.pages:
+    for page in index.get_pages():
         url = page.frontmatter.image
         if url is not None and url.startswith("http"):
             remote_urls.append(url)


### PR DESCRIPTION
Split from #206 

* Migrate category and tag pages to `/en/category/...` and `/en/tag/...`.
* Refactor storage of page data to prepare support for languages other than `en`.