### PR TITLE
Add language support to post list and sitemap

### DIFF
--- a/server/content.py
+++ b/server/content.py
@@ -6,7 +6,8 @@ import aiofiles
 import frontmatter as fm
 
 from . import resources, settings
-from .i18n import gettext_lazy as _, using_locale
+from .i18n import gettext_lazy as _
+from .i18n import using_locale
 from .models import ContentItem, Frontmatter, MetaTag, Page
 from .utils import to_production_url
 

--- a/server/i18n/__init__.py
+++ b/server/i18n/__init__.py
@@ -1,10 +1,11 @@
 from .gettext import gettext_lazy
 from .jinja2 import setup_jinja2
-from .locale import get_locale, set_locale
+from .locale import get_locale, set_locale, using_locale
 
 __all__ = [
     "gettext_lazy",
     "setup_jinja2",
     "get_locale",
     "set_locale",
+    "using_locale",
 ]

--- a/server/i18n/locale.py
+++ b/server/i18n/locale.py
@@ -1,5 +1,7 @@
 import logging
+from contextlib import contextmanager
 from contextvars import ContextVar
+from typing import Iterator
 
 from babel.core import Locale as _Locale
 from babel.support import NullTranslations, Translations
@@ -64,3 +66,13 @@ def set_locale(code: str) -> None:
 
 def get_locale() -> "Locale":
     return _locale_context.get()
+
+
+@contextmanager
+def using_locale(code: str) -> Iterator[None]:
+    initial = get_locale().language
+    set_locale(code)
+    try:
+        yield
+    finally:
+        set_locale(initial)

--- a/server/sitemap.py
+++ b/server/sitemap.py
@@ -2,6 +2,7 @@ from typing import List
 
 import asgi_sitemaps
 
+from . import settings
 from .models import Page
 from .resources import index
 
@@ -23,10 +24,13 @@ class PagesSitemap(asgi_sitemaps.Sitemap):
     protocol = "https"
 
     def items(self) -> List[Page]:
-        return index.get_pages()
+        pages = []
+        for language in settings.LANGUAGES:
+            pages.extend(index.get_i18n_aware_pages(language))
+        return pages
 
     def location(self, page: Page) -> str:
-        return f"/blog{page.permalink}"
+        return page.permalink
 
     def changefreq(self, path: str) -> str:
         return "weekly"

--- a/server/views.py
+++ b/server/views.py
@@ -26,7 +26,7 @@ class RenderPage(HTTPEndpoint):
     async def get(self, request: Request) -> Response:
         permalink = "/" + request.path_params["permalink"]
 
-        for page in resources.index.get_pages():
+        for page in resources.index.get_i18n_aware_pages():
             if page.permalink == permalink:
                 break
         else:

--- a/tests/drafts/fr/posts/2021/04/test-brouillon.md
+++ b/tests/drafts/fr/posts/2021/04/test-brouillon.md
@@ -1,0 +1,10 @@
+---
+title: "Test"
+description: "Un brouillon de test."
+date: "2021-04-29"
+category: tutorials
+tags:
+  - test
+---
+
+Un brouillon de test.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -46,6 +46,12 @@ async def test_extra_content_dirs(client: httpx.AsyncClient) -> None:
     assert resp.status_code == 200, resp.url
     assert "text/html" in resp.headers["content-type"]
 
+    url = "http://florimond.dev/fr/posts/2021/04/test-brouillon/"
+    resp = await client.get(url, allow_redirects=False)
+    assert resp.status_code == 200, resp.url
+    assert "text/html" in resp.headers["content-type"]
+    assert "Tutoriels" in resp.text  # Navbar
+
 
 KNOWN_CATEGORIES = ["tutorials", "essays", "retrospectives"]
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -39,6 +39,12 @@ async def test_tag(client: httpx.AsyncClient) -> None:
     assert resp.status_code == 200, resp.url
     assert "text/html" in resp.headers["content-type"]
 
+    url = "http://florimond.dev/fr/tag/test/"
+    resp = await client.get(url, allow_redirects=False)
+    assert resp.status_code == 200, resp.url
+    assert "text/html" in resp.headers["content-type"]
+    assert "Tutoriels" in resp.text  # Navbar
+
 
 async def test_extra_content_dirs(client: httpx.AsyncClient) -> None:
     url = "http://florimond.dev/en/posts/2020/01/test-draft/"
@@ -68,6 +74,14 @@ async def test_category(client: httpx.AsyncClient, category: str) -> None:
     resp = await client.get(url, allow_redirects=False)
     assert resp.status_code == 200, resp.url
     assert "text/html" in resp.headers["content-type"]
+
+
+async def test_category_i18n(client: httpx.AsyncClient) -> None:
+    url = "http://florimond.dev/fr/category/tutorials/"
+    resp = await client.get(url, allow_redirects=False)
+    assert resp.status_code == 200, resp.url
+    assert "text/html" in resp.headers["content-type"]
+    assert "Tutoriels" in resp.text  # Navbar
 
 
 async def test_not_found(client: httpx.AsyncClient) -> None:

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -35,7 +35,7 @@ def test_build_pages() -> None:
                 You should *really* care about readability.
                 """
             ),
-            location="posts/readability-counts.md",
+            location="en/posts/readability-counts.md",
         )
     ]
 
@@ -44,7 +44,7 @@ def test_build_pages() -> None:
 
     readability_counts, python, essays = pages["en"]
 
-    assert readability_counts.permalink == "/posts/readability-counts"
+    assert readability_counts.permalink == "/en/posts/readability-counts"
     assert readability_counts.frontmatter.title == title
     assert readability_counts.frontmatter.description == description
     assert readability_counts.frontmatter.date == date
@@ -53,7 +53,7 @@ def test_build_pages() -> None:
     assert readability_counts.frontmatter.image == image
 
     meta = [str(tag) for tag in readability_counts.meta]
-    url = "https://florimond.dev/posts/readability-counts/"
+    url = "https://florimond.dev/en/posts/readability-counts/"
     assert '<meta name="twitter:card" content="summary_large_image">' in meta
     assert f'<meta name="twitter:title" content="{title}">' in meta
     assert f'<meta name="twitter:description" content="{description}">' in meta
@@ -119,7 +119,7 @@ def test_image_auto_thumbnail(image: str, image_thumbnail: Optional[str]) -> Non
             ---
             """
         ),
-        location="posts/test.md",
+        location="en/posts/test.md",
     )
 
     (page,) = build_pages([item])["en"]

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -16,7 +16,7 @@ async def test_images(client: httpx.AsyncClient) -> None:
     All images linked in articles must exist and be local files.
     """
     remote_urls = []
-    for page in index.get_pages():
+    for page in index.get_i18n_aware_pages():
         url = page.frontmatter.image
         if url is not None and url.startswith("http"):
             remote_urls.append(url)


### PR DESCRIPTION
Split from #206 

Follow-up to #207 that makes it so that the home page (eg `/en/` or `/fr/`) only shows the list of posts in the current language.

Also update the sitemap generator to include pages from all languages.

So right now https://florimond.dev/fr/ would now be showing "No posts yet" (translating that bit will be done as a follow-up).