### PR TITLE
Internationalize link to home page

### DIFF
--- a/server/i18n/routing.py
+++ b/server/i18n/routing.py
@@ -1,7 +1,9 @@
 from typing import Tuple
 
 from starlette.datastructures import Scope
-from starlette.routing import Match, Route
+from starlette.routing import Match, Route, URLPath
+
+from .locale import get_locale
 
 
 class LocaleRoute(Route):
@@ -28,3 +30,13 @@ class LocaleRoute(Route):
         normalized_scope = {**scope, "path": path[len(language_prefix) :]}
 
         return super().matches(normalized_scope)
+
+    def url_path_for(self, name: str, **path_params: str) -> URLPath:
+        url_path = super().url_path_for(name, **path_params)
+        # Prepend language prefix
+        # Eg given LocaleRoute("/", name="home") and language="fr",
+        # url_for('home') would return "/fr/" (rather than "/").
+        locale = get_locale()
+        language_prefix = f"/{locale.language}"
+        assert not url_path.startswith(language_prefix)
+        return URLPath(f"{language_prefix}{url_path}")

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -11,7 +11,8 @@ async def test_i18n_home(client: httpx.AsyncClient) -> None:
     assert resp.status_code == 200
     assert "text/html" in resp.headers["content-type"]
 
-    assert "Tutoriels" in resp.text  # Navbar
+    assert f'href="{url}"' in resp.text  # Navbar home link is localized.
+    assert "Tutoriels" in resp.text  # Navbar categories are localized.
 
 
 @pytest.mark.asyncio

--- a/tests/test_legacy_redirect.py
+++ b/tests/test_legacy_redirect.py
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.asyncio
             [
                 ("http://blog.florimond.dev/", 301),
                 ("http://florimond.dev/blog/", 301),
-                ("http://florimond.dev/", 307),
+                ("http://florimond.dev/en/", 307),
             ],
             id="blog:home",
         ),


### PR DESCRIPTION
Follow-up to #206 

Link to home page is internationalized, so that eg it shows `https://florimond.dev/fr/` rather than `https://florimond.dev/` when visiting the French version of the site.

Coverage for staying on the same language throughout links should now be complete: home page, categories, links to posts on the home and post detail pages.

This is implemented by enhancing `LocaleRoute`, so that this functionality can be used for future i18n pages as well.

Next up:

* Add a language switch
* Auto-detect language based on request info (I believe browsers send a preferred language).