### PR TITLE
Finalize and test support for private links

### DIFF
--- a/locale/base.pot
+++ b/locale/base.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-04-29 22:31+0200\n"
+"POT-Creation-Date: 2021-09-14 23:16+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -49,5 +49,9 @@ msgstr ""
 
 #: server/templates/components/pages/post_list.jinja:10
 msgid "No posts yet."
+msgstr ""
+
+#: server/templates/views/page.jinja:21
+msgid "This is a private link: please do not share!"
 msgstr ""
 

--- a/locale/fr_FR/LC_MESSAGES/messages.po
+++ b/locale/fr_FR/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-04-29 22:31+0200\n"
+"POT-Creation-Date: 2021-09-14 23:16+0200\n"
 "PO-Revision-Date: 2021-04-22 16:27+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr_FR\n"
@@ -42,7 +42,9 @@ msgstr "Ingénieur logiciel et environnement"
 msgid ""
 "I maintain and contribute to libraries, packages, and tools. Mostly "
 "Python."
-msgstr "Je développe des logiciels libres et autres outils, principalement en Python. J'agis pour un numérique plus sobre et compatible +2°C."
+msgstr ""
+"Je développe des logiciels libres et autres outils, principalement en "
+"Python. J'agis pour un numérique plus sobre et compatible +2°C."
 
 #: server/templates/components/social_links.jinja:3
 msgid "Links"
@@ -51,4 +53,8 @@ msgstr "Liens utiles"
 #: server/templates/components/pages/post_list.jinja:10
 msgid "No posts yet."
 msgstr "Pas encore de billets."
+
+#: server/templates/views/page.jinja:21
+msgid "This is a private link: please do not share!"
+msgstr "Ce lien est privé : veuillez ne pas le partager !"
 

--- a/server/templates/views/page.jinja
+++ b/server/templates/views/page.jinja
@@ -18,7 +18,7 @@
 {% block content %}
 <main class="mt-6">
   {%- if page.is_private -%}
-  <p style="color: red; text-align: center;">Ce lien est privé : veuillez ne pas le partager !</p>
+  <p style="color: red; text-align: center;">{{ _("This is a private link: please do not share!") }}</p>
   {%- endif -%}
 
   {%- if page.frontmatter.tag -%}

--- a/tests/drafts/en/posts/2020/01/test-draft-prv-1.md
+++ b/tests/drafts/en/posts/2020/01/test-draft-prv-1.md
@@ -1,0 +1,10 @@
+---
+title: "Test"
+description: "Test"
+date: "2021-04-29"
+category: tutorials
+tags:
+  - test
+---
+
+A test draft, marked as private for review.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -59,6 +59,15 @@ async def test_extra_content_dirs(client: httpx.AsyncClient) -> None:
     assert "Tutoriels" in resp.text  # Navbar
 
 
+async def test_private_link(client: httpx.AsyncClient) -> None:
+    url = "http://florimond.dev/en/posts/2020/01/test-draft-prv-1/"
+    resp = await client.get(url, allow_redirects=False)
+    assert resp.status_code == 200, resp.url
+    assert "text/html" in resp.headers["content-type"]
+    assert "private link" in resp.text.lower()
+    assert "do not share" in resp.text.lower()
+
+
 KNOWN_CATEGORIES = ["tutorials", "essays", "retrospectives"]
 
 

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -124,3 +124,33 @@ def test_image_auto_thumbnail(image: str, image_thumbnail: Optional[str]) -> Non
 
     (page,) = build_pages([item])["en"]
     assert page.frontmatter.image_thumbnail == image_thumbnail
+
+
+@pytest.mark.parametrize(
+    "location, is_private",
+    [
+        ("en/posts/test.md", False),
+        ("en/posts/test-prv.md", False),
+        ("en/posts/test-prv-1.md", True),
+        ("en/posts/test-prv-3535.md", True),
+    ],
+)
+def test_is_private(location: str, is_private: bool) -> None:
+    items = [
+        ContentItem(
+            content=dedent(
+                """
+                ---
+                title: "Test"
+                description: "Test"
+                date: "2020-01-01"
+                ---
+                """
+            ),
+            location=location,
+        ),
+    ]
+
+    (page,) = build_pages(items)["en"]
+
+    assert page.is_private is is_private


### PR DESCRIPTION
Finalize and add tests for private link support, which was added to `master` via cc52bb8b00dc298f6cfabdb6930108c9ff6d3f7b

These "private links" are useful to share unfinished blog posts, e.g. with external reviewers.