### PR TITLE
Enable GZip compression

### DIFF
--- a/server/middleware.py
+++ b/server/middleware.py
@@ -1,6 +1,7 @@
 import typing
 
 from starlette.middleware import Middleware
+from starlette.middleware.gzip import GZipMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
@@ -11,6 +12,7 @@ from .i18n.middleware import LocaleMiddleware
 
 middleware = [
     # NOTE: Middleware executes from top to bottom.
+    Middleware(GZipMiddleware, minimum_size=1024),  # > 1kB only
     Middleware(
         legacy.LegacyRedirectMiddleware,
         url_mapping=settings.LEGACY_URL_MAPPING,

--- a/server/middleware.py
+++ b/server/middleware.py
@@ -1,8 +1,8 @@
 import typing
 
 from starlette.middleware import Middleware
-from starlette.middleware.gzip import GZipMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.middleware.gzip import GZipMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.types import ASGIApp

--- a/server/middleware.py
+++ b/server/middleware.py
@@ -12,7 +12,7 @@ from .i18n.middleware import LocaleMiddleware
 
 middleware = [
     # NOTE: Middleware executes from top to bottom.
-    Middleware(GZipMiddleware, minimum_size=1024),  # > 1kB only
+    Middleware(GZipMiddleware),
     Middleware(
         legacy.LegacyRedirectMiddleware,
         url_mapping=settings.LEGACY_URL_MAPPING,

--- a/tests/test_ecodesign.py
+++ b/tests/test_ecodesign.py
@@ -1,0 +1,17 @@
+"""
+Tests relative to the ecodesign of the application.
+
+Based on best practices from GreenIT-Analysis.
+"""
+
+import httpx
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_resources_compressed(client: httpx.AsyncClient) -> None:
+    url = "http://florimond.dev/"
+    headers = {"Accept-Encoding": "gzip, deflate"}
+    resp = await client.get(url, headers=headers, allow_redirects=False)
+    assert resp.status_code == 200
+    assert resp.headers["Content-Encoding"] == "gzip"


### PR DESCRIPTION
HTML responses and CSS/JS assets were not [compressed](https://en.wikipedia.org/wiki/HTTP_compression) yet. This PR adds GZip compression.

Comparison of page size / transfer size:

| Page | Size | Transfer size (`master`) | Transfer size (PR) | Transfer size reduction (%) |
|---|---|---|---|---|
| Home | 350 kB | 356 kB | 273 kB | ⬇️ -23.3% |
| Article <br> (_La Garonne à vélo_) | 481 kB | 430 kB | 260 kB  | ⬇️ -39.5% |