### PR TITLE
Add print stylesheet

### DIFF
--- a/server/styles/base.pcss
+++ b/server/styles/base.pcss
@@ -23,6 +23,21 @@ h3 {
   @apply text-lg;
 }
 
+@media print {
+  body {
+    font-size: 10pt;
+  }
+  h1 {
+    @apply text-xl;
+  }
+  h2 {
+    @apply text-lg;
+  }
+  h3 {
+    @apply text-base;
+  }
+}
+
 a:hover {
   @apply text-primary;
 }

--- a/server/styles/components.pcss
+++ b/server/styles/components.pcss
@@ -18,6 +18,24 @@
   @apply px-4;
 }
 
+.p-nav {
+  @apply .p-page-content;
+}
+.p-nav-wrapper {
+  @apply text-center;
+}
+@media screen and (min-width: theme("screens.tablet")), print {
+  .p-nav-wrapper {
+    @apply items-center;
+    @apply flex;
+    @apply justify-between;
+  }
+  .p-nav-links {
+    @apply flex;
+    @apply items-center;
+  }
+}
+
 .p-link {
   @apply border-b;
   @apply border-primary;
@@ -26,7 +44,7 @@
 .c-jumbotron-card {
   @apply text-center;
 }
-@media (min-width: theme("screens.tablet")) {
+@media screen and (min-width: theme("screens.tablet")), print {
   .c-jumbotron-card {
     @apply text-left;
     @apply grid;
@@ -42,14 +60,20 @@
   @apply mt-8;
 }
 
-@media (max-width: theme("screens.tablet")) {
+@media print {
+  .c-page-list-container {
+    @apply mx-0;
+  }
+}
+
+@media screen and (max-width: theme("screens.tablet")) {
   .c-page-list {
     @apply max-w-md;
     @apply mx-auto;
   }
 }
 
-@media (min-width: theme("screens.tablet")) {
+@media screen and (min-width: theme("screens.tablet")) {
   .c-page-list-container {
     @apply max-w-2xl;
   }
@@ -60,7 +84,7 @@
   }
 }
 
-@media (min-width: 1024px) {
+@media screen and (min-width: 1024px) {
   .c-page-list-container {
     @apply max-w-4xl;
   }
@@ -69,8 +93,27 @@
   }
 }
 
-.c-page-list-item {
-  @apply mb-12;
+@media screen {
+  .c-page-list-item {
+    @apply mb-12;
+  }
+}
+
+@media print {
+  .c-page-list-item {
+    @apply mb-6;
+    @apply grid;
+    @apply items-center;
+    @apply gap-x-4;
+    grid-template-columns: 1fr 4fr;
+  }
+}
+
+@media print {
+  .c-post-page h1 {
+    @apply text-xl;
+    @apply mb-2;
+  }
 }
 
 .c-post-meta {
@@ -98,11 +141,28 @@
 .markdown h2,
 .markdown h3 {
   @apply font-bold;
-  @apply mt-10;
-  @apply mb-6;
 }
-.markdown p {
-  @apply my-4;
+@media screen {
+  .markdown h1,
+  .markdown h2,
+  .markdown h3 {
+    @apply mt-10;
+    @apply mb-6;
+  }
+  .markdown p {
+    @apply my-4;
+  }
+}
+@media print {
+  .markdown h1,
+  .markdown h2,
+  .markdown h3 {
+    @apply mt-4;
+    @apply mb-2;
+  }
+  .markdown p {
+    @apply my-1;
+  }
 }
 .markdown a {
   @apply p-link;
@@ -117,7 +177,7 @@
   @apply list-disc;
   @apply list-outside;
   @apply pl-8;
-  @apply my-5;
+  @apply my-2;
 }
 .markdown .p-image > img {
   max-height: 20em;

--- a/server/templates/components/jumbotron.jinja
+++ b/server/templates/components/jumbotron.jinja
@@ -1,24 +1,24 @@
 {% from "components/utils/content_wrapper.jinja" import ContentWrapper with context %}
 
 {% macro Jumbotron() %}
-<div class="bg-surface p-10">
+<div class="bg-surface p-4">
   {% call ContentWrapper() %}
   <div class="c-jumbotron-card">
-    <img class="rounded-half w-32 h-32 mx-auto" src="{{ url_for('static', path='img/me.png') }}" alt="Picture of me" />
+    <img class="rounded-half w-32 h-32 mx-auto print:w-16 print:h-16" src="{{ url_for('static', path='img/me.png') }}" alt="Picture of me" />
     <div class="c-jumbotron-body">
-      <h1 class="font-bold text-3xl my-1">
+      <h1 class="font-bold text-3xl print:text-xl my-1">
         Florimond Manca
       </h1>
-      <h2 class="text-xl">
+      <h2 class="text-xl print:text-lg">
         {{ _('Open Source Developer, Idealist On A Journey') }}
       </h2>
-      <p class="text-muted mb-3">
+      <p class="text-muted">
         {{ _('I maintain and contribute to libraries, packages, and tools. Mostly Python.') }}
       </p>
     </div>
   </div>
 
-  <ul class="flex justify-center">
+  <ul class="flex justify-center mt-3 print:hidden">
     <li>
       <a class="inline-flex px-4 py-1" href="https://github.com/florimondmanca" target="_blank" rel="noopener">
         💻&nbsp;&nbsp;Code

--- a/server/templates/components/navbar.jinja
+++ b/server/templates/components/navbar.jinja
@@ -1,9 +1,9 @@
 {% from "components/utils/content_wrapper.jinja" import ContentWrapper with context %}
 
 {% macro NavBar() %}
-<nav class="p-page-content">
-  {% call ContentWrapper(class="text-center tablet:flex items-center justify-between") %}
-    <div class="tablet:flex tablet:items-center">
+<nav class="p-nav">
+  {% call ContentWrapper(class="p-nav-wrapper") %}
+    <div class="p-nav-links">
       <a class="inline-block text-lg font-bold py-2 pr-3" href="{{ url_for('home') }}">
         {{ settings.SITE_TITLE }}
       </a>

--- a/server/templates/components/pages/post_list_item.jinja
+++ b/server/templates/components/pages/post_list_item.jinja
@@ -16,18 +16,20 @@
     {% endif %}
   {% endwith %}
 
-  <h3 class="font-bold mt-1 mb-3">
-    <a href="{{ url_for('page', permalink=page.permalink.lstrip('/')) }}">
-      {{ page.frontmatter.title }}
-    </a>
-  </h3>
+  <div>
+    <h3 class="font-bold mt-1 mb-3">
+      <a href="{{ url_for('page', permalink=page.permalink.lstrip('/')) }}">
+        {{ page.frontmatter.title }}
+      </a>
+    </h3>
 
-  <p class="mb-2">
-    {{ page.frontmatter.description }}
-  </p>
+    <p class="mb-2">
+      {{ page.frontmatter.description }}
+    </p>
 
-  <small>
-    {{ PostMeta(page) }}
-  </small>
+    <small>
+      {{ PostMeta(page) }}
+    </small>
+  </div>
 </li>
 {% endmacro %}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -22,6 +22,11 @@ module.exports = {
         background: "#424242",
       },
     },
+    extend: {
+      screens: {
+        print: { raw: "print" }, // Allow `class="print:..."` = `@media print { ... }`
+      },
+    },
     fontFamily: {
       body: [
         "Garamond", // Windows, Mac


### PR DESCRIPTION
## Motivation

Currently, no `@media print` CSS rules are provided, which meant that printing the page (or generating a PDF) would output HTML in the default (i.e. mobile) style, i.e. with very wide margins and lots of empty spaces.

This PR adds proper `@media print` rules for a print-optimized layout, and makes a few spacing tweaks (jumbotron, lists).

## References

* https://github.com/tailwindlabs/tailwindcss/discussions/1425#discussioncomment-999

## Preview

![Capture d’écran 2021-09-22 à 14 19 06](https://user-images.githubusercontent.com/15911462/134342532-373ab867-80d8-4e84-b41c-d4a2639a9d77.png)

![Capture d’écran 2021-09-22 à 14 18 57](https://user-images.githubusercontent.com/15911462/134342542-20994d11-7e64-47c0-8de0-40560068ac32.png)

