### PR TITLE
Bump dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,18 +3,14 @@
 # Development, tools and testing dependencies.
 autoflake==1.4
 asgi-lifespan==1.0.1
-black==21.9b0
-exdown==0.8.8
-flake8==3.9.2
-flake8-bugbear==20.1.4
-flake8-comprehensions==3.5.0
-flake8-pie==0.6.1
-isort==5.5.4
-mypy==0.910
+black==21.12b0
+exdown==0.8.9
+flake8==4.0.1
+isort==5.10.1
+mypy==0.920
 Pillow==8.3.2
-pytest==6.2.3
-pytest-asyncio==0.15.1
-pytest-cov==2.12.1
-seed-isort-config==2.2.0
+pytest==6.2.5
+pytest-asyncio==0.16.0
+pytest-cov==3.0.0
 types-markdown==3.3.2
-types-aiofiles==0.1.9
+types-aiofiles==0.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 # Runtime dependencies.
-aiofiles==0.7.0
+aiofiles==0.8.0
 arel==0.2.0
 asgi-sitemaps==0.3.2
-babel==2.9.0
+babel==2.9.1
 gunicorn==20.1.0
-httpx==0.18.2
-jinja2==2.11.3
-markdown==3.3.4
-pygments==2.9.0
+httpx==0.21.1
+jinja2==3.0.3
+markdown==3.3.6
+pygments==2.10.0
 python-frontmatter==0.5.0
-starlette==0.14.2
-uvicorn[standard]==0.15.0
+starlette==0.17.1
+uvicorn[standard]==0.16.0

--- a/scripts/lint
+++ b/scripts/lint
@@ -10,7 +10,6 @@ export SOURCE_FILES="server tests"
 set -x
 
 ${PREFIX}autoflake --in-place --recursive $SOURCE_FILES
-${PREFIX}seed-isort-config --application-directories=server
 ${PREFIX}isort $SOURCE_FILES
 ${PREFIX}black $SOURCE_FILES
 ${PREFIX}python -m server.tools.mdformat

--- a/server/reload.py
+++ b/server/reload.py
@@ -12,7 +12,10 @@ async def on_reload() -> None:  # pragma: no cover
 hotreload = arel.HotReload(
     paths=[
         arel.Path("./content", on_reload=[on_reload]),
-        *(arel.Path(d, on_reload=[on_reload]) for d in settings.EXTRA_CONTENT_DIRS),
+        *(
+            arel.Path(str(d), on_reload=[on_reload])
+            for d in settings.EXTRA_CONTENT_DIRS
+        ),
         arel.Path("./server/templates"),
         arel.Path("./server/static"),
     ]

--- a/server/settings.py
+++ b/server/settings.py
@@ -37,11 +37,10 @@ LANGUAGE_LABELS = {
 }
 DEFAULT_LANGUAGE = "en"
 
-EXTRA_CONTENT_DIRS = config(
-    "EXTRA_CONTENT_DIRS",
-    cast=lambda v: [pathlib.Path(item) for item in CommaSeparatedStrings(v)],
-    default="",
-)
+EXTRA_CONTENT_DIRS = [
+    pathlib.Path(item)
+    for item in config("EXTRA_CONTENT_DIRS", cast=CommaSeparatedStrings, default="")
+]
 
 # Images take too much room on the Web. Let's limit ourselves
 # to reasonable sizes only.

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,8 +11,6 @@ ignore_missing_imports = True
 
 [tool:isort]
 profile = black
-known_first_party = server
-known_third_party = PIL,aiofiles,arel,asgi_lifespan,asgi_sitemaps,babel,black,exdown,frontmatter,httpx,markdown,pytest,starlette
 
 [tool:pytest]
 addopts = tests --cov=server --cov-report=term-missing -rxXs

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -12,21 +12,21 @@ pytestmark = pytest.mark.asyncio
 
 async def test_root(client: httpx.AsyncClient) -> None:
     url = "http://florimond.dev/"
-    resp = await client.get(url, allow_redirects=False)
+    resp = await client.get(url)
     assert resp.status_code == 200
     assert "text/html" in resp.headers["content-type"]
 
 
 async def test_article(client: httpx.AsyncClient) -> None:
     url = "http://florimond.dev/en/posts/2018/07/let-the-journey-begin/"
-    resp = await client.get(url, allow_redirects=False)
+    resp = await client.get(url)
     assert resp.status_code == 200
     assert "text/html" in resp.headers["content-type"]
 
 
 async def test_article_no_trailing_slash(client: httpx.AsyncClient) -> None:
     url = "http://florimond.dev/en/posts/2018/07/let-the-journey-begin"
-    resp = await client.get(url, allow_redirects=False)
+    resp = await client.get(url)
     assert resp.status_code == 307
     assert resp.headers["Location"] == (
         "http://florimond.dev/en/posts/2018/07/let-the-journey-begin/"
@@ -35,12 +35,12 @@ async def test_article_no_trailing_slash(client: httpx.AsyncClient) -> None:
 
 async def test_tag(client: httpx.AsyncClient) -> None:
     url = "http://florimond.dev/en/tag/python/"
-    resp = await client.get(url, allow_redirects=False)
+    resp = await client.get(url)
     assert resp.status_code == 200, resp.url
     assert "text/html" in resp.headers["content-type"]
 
     url = "http://florimond.dev/fr/tag/test/"
-    resp = await client.get(url, allow_redirects=False)
+    resp = await client.get(url)
     assert resp.status_code == 200, resp.url
     assert "text/html" in resp.headers["content-type"]
     assert "Tutoriels" in resp.text  # Navbar
@@ -48,12 +48,12 @@ async def test_tag(client: httpx.AsyncClient) -> None:
 
 async def test_extra_content_dirs(client: httpx.AsyncClient) -> None:
     url = "http://florimond.dev/en/posts/2020/01/test-draft/"
-    resp = await client.get(url, allow_redirects=False)
+    resp = await client.get(url)
     assert resp.status_code == 200, resp.url
     assert "text/html" in resp.headers["content-type"]
 
     url = "http://florimond.dev/fr/posts/2021/04/test-brouillon/"
-    resp = await client.get(url, allow_redirects=False)
+    resp = await client.get(url)
     assert resp.status_code == 200, resp.url
     assert "text/html" in resp.headers["content-type"]
     assert "Tutoriels" in resp.text  # Navbar
@@ -61,7 +61,7 @@ async def test_extra_content_dirs(client: httpx.AsyncClient) -> None:
 
 async def test_private_link(client: httpx.AsyncClient) -> None:
     url = "http://florimond.dev/en/posts/2020/01/test-draft-prv-1/"
-    resp = await client.get(url, allow_redirects=False)
+    resp = await client.get(url)
     assert resp.status_code == 200, resp.url
     assert "text/html" in resp.headers["content-type"]
     assert "private link" in resp.text.lower()
@@ -80,14 +80,14 @@ def test_known_categories() -> None:
 @pytest.mark.parametrize("category", KNOWN_CATEGORIES)
 async def test_category(client: httpx.AsyncClient, category: str) -> None:
     url = f"http://florimond.dev/en/category/{category}/"
-    resp = await client.get(url, allow_redirects=False)
+    resp = await client.get(url)
     assert resp.status_code == 200, resp.url
     assert "text/html" in resp.headers["content-type"]
 
 
 async def test_category_i18n(client: httpx.AsyncClient) -> None:
     url = "http://florimond.dev/fr/category/tutorials/"
-    resp = await client.get(url, allow_redirects=False)
+    resp = await client.get(url)
     assert resp.status_code == 200, resp.url
     assert "text/html" in resp.headers["content-type"]
     assert "Tutoriels" in resp.text  # Navbar
@@ -95,14 +95,14 @@ async def test_category_i18n(client: httpx.AsyncClient) -> None:
 
 async def test_not_found(client: httpx.AsyncClient) -> None:
     url = "http://florimond.dev/foo"
-    resp = await client.get(url)
+    resp = await client.get(url, follow_redirects=True)
     assert resp.status_code == 404
     assert "text/html" in resp.headers["content-type"]
 
 
 async def test_internal_server_error(silent_client: httpx.AsyncClient) -> None:
     url = "http://florimond.dev/error"
-    resp = await silent_client.get(url)
+    resp = await silent_client.get(url, follow_redirects=True)
     assert resp.status_code == 500
     assert "text/html" in resp.headers["content-type"]
 
@@ -140,7 +140,7 @@ async def test_rss_link(client: httpx.AsyncClient) -> None:
 
 async def test_meta(client: httpx.AsyncClient) -> None:
     url = "http://florimond.dev/en/posts/2018/07/let-the-journey-begin/"
-    resp = await client.get(url, allow_redirects=False)
+    resp = await client.get(url)
     assert resp.status_code == 200
     assert "text/html" in resp.headers["content-type"]
 

--- a/tests/test_ecodesign.py
+++ b/tests/test_ecodesign.py
@@ -12,6 +12,6 @@ import pytest
 async def test_resources_compressed(client: httpx.AsyncClient) -> None:
     url = "http://florimond.dev/"
     headers = {"Accept-Encoding": "gzip, deflate"}
-    resp = await client.get(url, headers=headers, allow_redirects=False)
+    resp = await client.get(url, headers=headers)
     assert resp.status_code == 200
     assert resp.headers["Content-Encoding"] == "gzip"

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -7,7 +7,7 @@ from server.i18n import get_locale, set_locale
 @pytest.mark.asyncio
 async def test_i18n_home(client: httpx.AsyncClient) -> None:
     url = "http://florimond.dev/fr/"
-    resp = await client.get(url, allow_redirects=False)
+    resp = await client.get(url)
     assert resp.status_code == 200
     assert "text/html" in resp.headers["content-type"]
 
@@ -19,7 +19,7 @@ async def test_i18n_home(client: httpx.AsyncClient) -> None:
 @pytest.mark.asyncio
 async def test_i18n_unknown_language(client: httpx.AsyncClient) -> None:
     url = "http://florimond.dev/de/"
-    resp = await client.get(url, allow_redirects=False)
+    resp = await client.get(url)
     assert resp.status_code == 404
     assert "text/html" in resp.headers["content-type"]
 

--- a/tests/test_legacy_redirect.py
+++ b/tests/test_legacy_redirect.py
@@ -54,7 +54,7 @@ pytestmark = pytest.mark.asyncio
 async def test_legacy_redirect_chains(
     client: httpx.AsyncClient, start_url: str, urls: typing.List[str]
 ) -> None:
-    resp = await client.get(start_url, allow_redirects=True)
+    resp = await client.get(start_url, follow_redirects=True)
     assert resp.status_code == 200
     assert [(r.headers["Location"], r.status_code) for r in resp.history] == urls
 
@@ -168,13 +168,11 @@ async def test_legacy_redirect_articles(
 ) -> None:
     # blog.florimond.dev/xyz -> florimond.dev/en/posts/xyz
     resp = await client.get(
-        f"https://blog.florimond.dev{legacy_path}", allow_redirects=True
+        f"https://blog.florimond.dev{legacy_path}", follow_redirects=True
     )
     assert resp.status_code == 200
     assert resp.url == f"https://florimond.dev{path}"
 
     # No such redirection for florimond.dev/xyz/ (these URLs have never existed).
-    resp = await client.get(
-        f"https://florimond.dev{legacy_path}/", allow_redirects=False
-    )
+    resp = await client.get(f"https://florimond.dev{legacy_path}/")
     assert resp.status_code == 404


### PR DESCRIPTION
Batch of dependency bumps

NOTE: `exdown` is marked as deprecated. It turned to extracting code-blocks for pytest usage, rather than further manipulation like we do. Might need to revive #254...