### PR TITLE
Update CI "Build" job and templates version

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -4,7 +4,7 @@ resources:
       type: github
       endpoint: github
       name: florimondmanca/azure-pipelines-templates
-      ref: refs/heads/master
+      ref: refs/tags/5.0
 
 trigger:
   - master
@@ -24,6 +24,8 @@ jobs:
       pythonVersion: "3.10"
 
   - job: Build
+    pool:
+      vmImage: "ubuntu-latest"
     steps:
       - template: step--yarn-provision.yml@templates
         parameters:


### PR DESCRIPTION
`Build` job was not specifying an Ubuntu version, so it was using Ubuntu 16 which is not supported by AZP anymore. AZP wants us to specify a version explicitly, here using `ubuntu-latest` as in other AZP templates.