### PR TITLE
Refactor: use a main module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ serve:
 	make -j 2 serve-uvicorn serve-tailwind
 
 serve-uvicorn:
-	${bin}uvicorn server:app --reload --use-colors 2>&1 | ${bin}python -m tools.colorprefix blue [server]
+	${bin}python -m server.main 2>&1 | ${bin}python -m tools.colorprefix blue [server]
 
 serve-tailwind:
 	NODE_ENV=production FORCE_COLOR=true yarn watch 2>&1 | ${bin}python -m tools.colorprefix yellow [tailwind]

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn -b 0.0.0.0:${PORT} -w 1 -k uvicorn.workers.UvicornWorker server:app
+web: gunicorn -b 0.0.0.0:${PORT} -w 1 -k uvicorn.workers.UvicornWorker server.main:app

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,3 +1,0 @@
-from .app import app
-
-__all__ = ["app"]

--- a/server/app.py
+++ b/server/app.py
@@ -1,14 +1,17 @@
 from starlette.applications import Starlette
+from starlette.types import ASGIApp
 
 from . import event_handlers, settings, views
 from .middleware import middleware
 from .routes import routes
 
-app = Starlette(
-    debug=settings.DEBUG,
-    routes=routes,
-    middleware=middleware,
-    exception_handlers={404: views.not_found, 500: views.internal_server_error},
-    on_startup=event_handlers.on_startup,
-    on_shutdown=event_handlers.on_shutdown,
-)
+
+def create_app() -> ASGIApp:
+    return Starlette(
+        debug=settings.DEBUG,
+        routes=routes,
+        middleware=middleware,
+        exception_handlers={404: views.not_found, 500: views.internal_server_error},
+        on_startup=event_handlers.on_startup,
+        on_shutdown=event_handlers.on_shutdown,
+    )

--- a/server/main.py
+++ b/server/main.py
@@ -1,0 +1,8 @@
+import uvicorn
+
+from .app import create_app
+
+app = create_app()
+
+if __name__ == "__main__":
+    uvicorn.run("server.main:app", reload=True, use_colors=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,10 +25,10 @@ def event_loop() -> typing.Iterator[asyncio.AbstractEventLoop]:
 
 @pytest_asyncio.fixture(scope="session")
 async def app() -> typing.AsyncIterator[ASGIApp]:
-    import server
+    from server.main import app
 
-    async with LifespanManager(server.app):
-        yield server.app
+    async with LifespanManager(app):
+        yield app
 
 
 @pytest_asyncio.fixture(scope="session")


### PR DESCRIPTION
It's very easy to end up with circular imports because of the import of `app` in `server/__init__.py`.

This PR moves that to a separate module, that's specifically imported by uvicorn/gunicorn.