### PR TITLE
Update type hints

### DIFF
--- a/server/domain/repositories.py
+++ b/server/domain/repositories.py
@@ -1,23 +1,17 @@
-import typing
-
 from .entities import Page
 
 
 class PageRepository:
-    def find_by_permalink(self, permalink: str) -> typing.Optional[Page]:
+    def find_by_permalink(self, permalink: str) -> Page | None:
         raise NotImplementedError  # pragma: no cover
 
-    def find_all(self, language: str = None) -> typing.List[Page]:
+    def find_all(self, language: str = None) -> list[Page]:
         raise NotImplementedError  # pragma: no cover
 
     def find_all_post_pages(
-        self,
-        *,
-        tag: str = None,
-        category: str = None,
-        limit: int = None,
-    ) -> typing.List[Page]:
+        self, *, tag: str = None, category: str = None, limit: int = None
+    ) -> list[Page]:
         raise NotImplementedError  # pragma: no cover
 
-    def find_all_category_pages(self) -> typing.List[Page]:
+    def find_all_category_pages(self) -> list[Page]:
         raise NotImplementedError  # pragma: no cover

--- a/server/web/middleware.py
+++ b/server/web/middleware.py
@@ -1,4 +1,4 @@
-import typing
+from typing import Callable
 
 from starlette.middleware import Middleware
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -31,7 +31,7 @@ class PatchHeadersMiddleware(BaseHTTPMiddleware):
         super().__init__(app)
         self.headers = headers
 
-    async def dispatch(self, request: Request, call_next: typing.Callable) -> Response:
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
         response = await call_next(request)
         response.headers.update(self.headers)
         return response

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 import asyncio
 import os
-import typing
+from typing import AsyncIterator, Iterator
 
 import httpx
 import pytest
@@ -14,7 +14,7 @@ os.environ["EXTRA_CONTENT_DIRS"] = "tests/drafts"
 
 
 @pytest.fixture(scope="session")
-def event_loop() -> typing.Iterator[asyncio.AbstractEventLoop]:
+def event_loop() -> Iterator[asyncio.AbstractEventLoop]:
     """
     Redefine from pytest-asyncio, as the default fixture is function-scoped.
     """
@@ -24,7 +24,7 @@ def event_loop() -> typing.Iterator[asyncio.AbstractEventLoop]:
 
 
 @pytest_asyncio.fixture(scope="session")
-async def app() -> typing.AsyncIterator[ASGIApp]:
+async def app() -> AsyncIterator[ASGIApp]:
     from server.main import app
 
     async with LifespanManager(app):
@@ -32,13 +32,13 @@ async def app() -> typing.AsyncIterator[ASGIApp]:
 
 
 @pytest_asyncio.fixture(scope="session")
-async def client(app: ASGIApp) -> typing.AsyncIterator[httpx.AsyncClient]:
+async def client(app: ASGIApp) -> AsyncIterator[httpx.AsyncClient]:
     async with httpx.AsyncClient(app=app, base_url="http://testserver") as client:
         yield client
 
 
 @pytest_asyncio.fixture(scope="session")
-async def silent_client(app: ASGIApp) -> typing.AsyncIterator[httpx.AsyncClient]:
+async def silent_client(app: ASGIApp) -> AsyncIterator[httpx.AsyncClient]:
     transport = httpx.ASGITransport(app, raise_app_exceptions=False)
     async with httpx.AsyncClient(transport=transport) as client:
         yield client

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,3 @@
-import typing
-
 import httpx
 import pytest
 
@@ -160,7 +158,7 @@ async def test_meta(client: httpx.AsyncClient) -> None:
 
     meta = find_meta_tags(resp.text)
 
-    def find_meta(typ: str, value: str) -> typing.Optional[dict]:
+    def find_meta(typ: str, value: str) -> dict | None:
         for item in meta:
             if item.get(typ) == value:
                 return item.get("content")

--- a/tests/test_legacy_redirect.py
+++ b/tests/test_legacy_redirect.py
@@ -1,5 +1,3 @@
-import typing
-
 import httpx
 import pytest
 
@@ -51,7 +49,7 @@ import pytest
     ],
 )
 async def test_legacy_redirect_chains(
-    client: httpx.AsyncClient, start_url: str, urls: typing.List[str]
+    client: httpx.AsyncClient, start_url: str, urls: list[str]
 ) -> None:
     resp = await client.get(start_url, follow_redirects=True)
     assert resp.status_code == 200

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,3 @@
-import typing
 from html.parser import HTMLParser
 from xml.dom import minidom
 
@@ -11,11 +10,9 @@ class HeadMetaHTMLParser(HTMLParser):
     def __init__(self) -> None:
         super().__init__()
         self.in_head = False
-        self.meta: typing.List[dict] = []
+        self.meta: list[dict] = []
 
-    def handle_starttag(
-        self, tag: str, attrs: typing.List[typing.Tuple[str, typing.Optional[str]]]
-    ) -> None:
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         if tag == "head":
             self.in_head = True
         elif self.in_head and tag == "meta":


### PR DESCRIPTION
* Drop `typing.*` usage that can now be built-in annotations, eg. `list[str]`
* Switch from `import typing; typing.X` to `from typing import X`