### PR TITLE
Turn Frontmatter entity into Metadata entity

### DIFF
--- a/server/domain/entities.py
+++ b/server/domain/entities.py
@@ -15,7 +15,7 @@ class Tag:
 
 
 @dataclasses.dataclass(frozen=True)
-class Frontmatter:
+class Metadata:
     title: str
     description: Optional[str] = None
     category: Optional[str] = None
@@ -30,8 +30,7 @@ class Frontmatter:
 @dataclasses.dataclass(frozen=True)
 class Page:
     permalink: str
-    frontmatter: Frontmatter
-    meta: List[dict]
+    metadata: Metadata
     html: str = ""
     content: str = ""
 

--- a/server/infrastructure/adapters/frontmatter.py
+++ b/server/infrastructure/adapters/frontmatter.py
@@ -1,8 +1,0 @@
-from typing import Any
-
-import frontmatter
-
-
-def decode(content: str) -> tuple[str, dict[str, Any]]:
-    post = frontmatter.loads(content)
-    return post.content, dict(post)

--- a/server/infrastructure/html.py
+++ b/server/infrastructure/html.py
@@ -1,0 +1,42 @@
+from .. import settings
+from ..domain.entities import Page
+from .urls import to_production_url
+
+
+def build_meta_tags(page: Page) -> list[dict]:
+    path = page.permalink + ("" if page.permalink.endswith("/") else "/")
+    url = to_production_url(path)
+
+    image_url = page.metadata.image
+    if image_url:
+        image_url = to_production_url(image_url)
+
+    meta_tags: list[dict[str, str | None]] = [
+        # General
+        dict(name="description", content=page.metadata.description),
+        dict(name="image", content=image_url),
+        dict(itemprop="name", content=page.metadata.title),
+        dict(itemprop="description", content=page.metadata.description),
+        # Twitter
+        dict(name="twitter:url", content=url),
+        dict(name="twitter:title", content=page.metadata.title),
+        dict(name="twitter:description", content=page.metadata.description),
+        dict(name="twitter:image", content=image_url),
+        dict(name="twitter:card", content="summary_large_image"),
+        dict(name="twitter:site", content="@florimondmanca"),
+        # OpenGraph
+        dict(property="og:url", content=url),
+        dict(property="og:type", content="article"),
+        dict(property="og:title", content=page.metadata.title),
+        dict(property="og:description", content=page.metadata.description),
+        dict(property="og:image", content=image_url),
+        dict(property="og:site_name", content=settings.SITE_TITLE),
+        dict(property="article:published_time", content=page.metadata.date),
+    ]
+
+    for tag in page.metadata.tags:
+        meta_tags.append(dict(property="article:tag", content=tag.slug))
+
+    meta_tags = [attrs for attrs in meta_tags if attrs["content"] is not None]
+
+    return meta_tags

--- a/server/infrastructure/repositories.py
+++ b/server/infrastructure/repositories.py
@@ -24,7 +24,7 @@ class InMemoryPageRepository(PageRepository):
         category: str = None,
         limit: int = None,
     ) -> list[Page]:
-        posts = []
+        posts: list[Page] = []
 
         for page in self.find_all():
             if not page.is_post:
@@ -32,15 +32,13 @@ class InMemoryPageRepository(PageRepository):
             if page.is_private:
                 continue
             if tag__slug is not None:
-                if any(tag.slug == tag__slug for tag in page.frontmatter.tags):
+                if any(tag.slug == tag__slug for tag in page.metadata.tags):
                     continue
-            if category is not None and page.frontmatter.category != category:
+            if category is not None and page.metadata.category != category:
                 continue
             posts.append(page)
 
-        posts = sorted(
-            posts, key=lambda page: page.frontmatter.date or "", reverse=True
-        )
+        posts = sorted(posts, key=lambda page: page.metadata.date or "", reverse=True)
 
         return posts[:limit]
 

--- a/server/web/templates/components/meta.jinja
+++ b/server/web/templates/components/meta.jinja
@@ -1,3 +1,5 @@
-{% macro MetaTag(attributes) %}
-<meta {% for key, value in attributes.items() %}{% if value %}{{ key }}="{{ value }}"{% endif %}{% endfor %} />
+{% macro MetaTags(page) %}
+{% for attributes in page | meta_tags %}
+<meta {% for key, value in attributes.items() %}{{ key }}="{{ value }}"{% endfor %}>
+{% endfor %}
 {% endmacro %}

--- a/server/web/templates/components/navbar.jinja
+++ b/server/web/templates/components/navbar.jinja
@@ -11,7 +11,7 @@
         {% for page in get_category_pages() %}
         <li>
           <a class="px-4" href="{{ url_for('page', permalink=page.permalink.lstrip('/')) }}">
-            {{ page.frontmatter.category | category_label }}
+            {{ page.metadata.category | category_label }}
           </a>
         </li>
         {% endfor %}

--- a/server/web/templates/components/pages/post.jinja
+++ b/server/web/templates/components/pages/post.jinja
@@ -10,24 +10,24 @@
     </div>
 
     <h1 class="text-3xl font-bold mt-2 mb-4 leading-sm">
-      {{ page.frontmatter.title }}
+      {{ page.metadata.title }}
     </h1>
 
-    {% if page.frontmatter.description -%}
+    {% if page.metadata.description -%}
       <p class="text-muted-500 mb-6">
-        {{ page.frontmatter.description }}
+        {{ page.metadata.description }}
       </p>
     {%- endif %}
 
-    {% if page.frontmatter.image -%}
+    {% if page.metadata.image -%}
       <div class="p-image">
         <img
-          src="{{ page.frontmatter.image }}"
-          alt="{{ page.frontmatter.image_caption or '' }}"
+          src="{{ page.metadata.image }}"
+          alt="{{ page.metadata.image_caption or '' }}"
         />
-        {% if page.frontmatter.image_caption -%}
+        {% if page.metadata.image_caption -%}
           <figcaption>
-            {{ page.frontmatter.image_caption }}
+            {{ page.metadata.image_caption }}
           </figcaption>
         {%- endif %}
       </div>

--- a/server/web/templates/components/pages/post_list_item.jinja
+++ b/server/web/templates/components/pages/post_list_item.jinja
@@ -2,7 +2,7 @@
 
 {% macro PostListItem(page) %}
 <li class="c-page-list-item">
-  {% with image_src = page.frontmatter.image_thumbnail or page.frontmatter.image %}
+  {% with image_src = page.metadata.image_thumbnail or page.metadata.image %}
     {% if image_src %}
     <div class="text-center">
       <a href="{{ url_for('page', permalink=page.permalink.lstrip('/')) }}" class="inline-block mb-3">
@@ -15,12 +15,12 @@
   <div>
     <h3 class="font-bold mt-1 mb-3">
       <a href="{{ url_for('page', permalink=page.permalink.lstrip('/')) }}">
-        {{ page.frontmatter.title }}
+        {{ page.metadata.title }}
       </a>
     </h3>
 
     <p class="mb-2">
-      {{ page.frontmatter.description }}
+      {{ page.metadata.description }}
     </p>
 
     <small>

--- a/server/web/templates/components/pages/post_meta.jinja
+++ b/server/web/templates/components/pages/post_meta.jinja
@@ -3,15 +3,15 @@
 {% macro PostMeta(page, editable=false) %}
 <div class="c-post-meta">
   <div class="text-muted-500 pr-3">
-    {{ page.frontmatter.date | dateformat }}
+    {{ page.metadata.date | dateformat }}
     |
     in
-    <a href="{{ url_for('page', permalink=i18n_path('/category/' + page.frontmatter.category).lstrip('/')) }}">
-      {{ page.frontmatter.category | category_label }}
+    <a href="{{ url_for('page', permalink=i18n_path('/category/' + page.metadata.category).lstrip('/')) }}">
+      {{ page.metadata.category | category_label }}
     </a>
   </div>
 
-  {{ TagList(page.frontmatter.tags) }}
+  {{ TagList(page.metadata.tags) }}
 </div>
 
 {% if editable %}

--- a/server/web/templates/views/page.jinja
+++ b/server/web/templates/views/page.jinja
@@ -1,19 +1,17 @@
 {% extends "base.jinja" %}
 
-{% from "components/meta.jinja" import MetaTag with context %}
+{% from "components/meta.jinja" import MetaTags with context %}
 {% from "components/pages/tag_page.jinja" import TagPage with context %}
 {% from "components/pages/category_page.jinja" import CategoryPage with context %}
 {% from "components/pages/post.jinja" import PostPage with context %}
 
 {% block head %}
   {{ super() }}
-  {% for attributes in page.meta -%}
-    {{ MetaTag(attributes) }}
-  {%- endfor %}
+  {{ MetaTags(page) }}
 {% endblock head %}
 
 {% block title %}
-  {{ page.frontmatter.title or settings.SITE_TITLE }}
+  {{ page.metadata.title or settings.SITE_TITLE }}
 {% endblock title %}
 
 {% block content %}
@@ -22,14 +20,14 @@
   <p style="color: red; text-align: center;">{{ _("This is a private link: please do not share!") }}</p>
   {%- endif -%}
 
-  {%- if page.frontmatter.tag -%}
-    {{ TagPage(page.frontmatter.tag, get_post_pages(tag__slug=page.frontmatter.tag.slug)) }}
+  {%- if page.metadata.tag -%}
+    {{ TagPage(page.metadata.tag, get_post_pages(tag__slug=page.metadata.tag.slug)) }}
   {%- elif page.is_post -%}
     <div class="px-4 code-container">
       {{ PostPage(page) }}
     </div>
   {%- elif page.is_category -%}
-    {{ CategoryPage(page.frontmatter.category, get_post_pages(category=page.frontmatter.category)) }}
+    {{ CategoryPage(page.metadata.category, get_post_pages(category=page.metadata.category)) }}
   {%- else -%}
     {{ raise("Unknown page type") }}
   {%- endif -%}

--- a/server/web/templating.py
+++ b/server/web/templating.py
@@ -5,6 +5,7 @@ from starlette.exceptions import HTTPException
 from starlette.templating import Jinja2Templates
 
 from .. import settings
+from ..infrastructure.html import build_meta_tags
 from ..infrastructure.pages import get_category_label as category_label
 from . import i18n
 from .reload import HotReload
@@ -17,25 +18,26 @@ class Templates(Jinja2Templates):
         i18n.setup_jinja2(self)
 
         self.env.globals["now"] = dt.datetime.now
-        self.env.globals["raise"] = self._raise_server_error
+        self.env.globals["raise"] = _raise_server_error
         self.env.globals["settings"] = settings
         self.env.globals["hotreload"] = hotreload
-        self.env.filters["dateformat"] = self._dateformat
+        self.env.filters["dateformat"] = _dateformat
         self.env.filters["category_label"] = category_label
-        self.env.filters["language_label"] = self._language_label
-
-    @staticmethod
-    def _raise_server_error(message: str) -> None:  # pragma: no cover
-        raise HTTPException(500, detail=message)
-
-    @staticmethod
-    def _dateformat(value: str) -> str:
-        datevalue = dt.datetime.strptime(value, "%Y-%m-%d")
-        return datevalue.strftime("%b %d, %Y")
-
-    @staticmethod
-    def _language_label(value: str) -> str:
-        return settings.LANGUAGE_LABELS.get(value, value)
+        self.env.filters["language_label"] = _language_label
+        self.env.filters["meta_tags"] = build_meta_tags
 
     def from_string(self, source: str) -> jinja2.Template:
         return self.env.from_string(source)
+
+
+def _raise_server_error(message: str) -> None:  # pragma: no cover
+    raise HTTPException(500, detail=message)
+
+
+def _dateformat(value: str) -> str:
+    datevalue = dt.datetime.strptime(value, "%Y-%m-%d")
+    return datevalue.strftime("%b %d, %Y")
+
+
+def _language_label(value: str) -> str:
+    return settings.LANGUAGE_LABELS.get(value, value)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -77,7 +77,7 @@ KNOWN_CATEGORIES = ["tutorials", "essays", "retrospectives"]
 def test_known_categories() -> None:
     page_repository = resolve(PageRepository)
     pages = page_repository.find_all_category_pages()
-    categories = [page.frontmatter.category for page in pages]
+    categories = [page.metadata.category for page in pages]
     assert categories == KNOWN_CATEGORIES
 
 

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -6,6 +6,7 @@ import pytest
 
 from server.domain.entities import Tag
 from server.infrastructure.filesystem import ContentItem
+from server.infrastructure.html import build_meta_tags
 from server.infrastructure.pages import build_pages
 
 
@@ -46,14 +47,14 @@ def test_build_pages() -> None:
     readability_counts, python, essays = pages
 
     assert readability_counts.permalink == "/en/posts/readability-counts"
-    assert readability_counts.frontmatter.title == title
-    assert readability_counts.frontmatter.description == description
-    assert readability_counts.frontmatter.date == date
-    assert readability_counts.frontmatter.category == category
-    assert readability_counts.frontmatter.tags == [Tag("python")]
-    assert readability_counts.frontmatter.image == image
+    assert readability_counts.metadata.title == title
+    assert readability_counts.metadata.description == description
+    assert readability_counts.metadata.date == date
+    assert readability_counts.metadata.category == category
+    assert readability_counts.metadata.tags == [Tag("python")]
+    assert readability_counts.metadata.image == image
 
-    meta = readability_counts.meta
+    meta = build_meta_tags(readability_counts)
     url = "https://florimond.dev/en/posts/readability-counts/"
     assert {"name": "twitter:card", "content": "summary_large_image"} in meta
     assert {"name": "twitter:title", "content": title} in meta
@@ -67,36 +68,36 @@ def test_build_pages() -> None:
     )
 
     assert python.permalink == "/en/tag/python"
-    assert python.frontmatter.title
-    assert python.frontmatter.description
-    assert python.frontmatter.date is None
-    assert python.frontmatter.tags == []
-    assert python.frontmatter.tag == Tag("python")
+    assert python.metadata.title
+    assert python.metadata.description
+    assert python.metadata.date is None
+    assert python.metadata.tags == []
+    assert python.metadata.tag == Tag("python")
 
-    meta = python.meta
+    meta = build_meta_tags(python)
     url = "https://florimond.dev/en/tag/python/"
     assert {"name": "twitter:card", "content": "summary_large_image"} in meta
-    assert {"name": "twitter:title", "content": python.frontmatter.title} in meta
+    assert {"name": "twitter:title", "content": python.metadata.title} in meta
     assert {
         "name": "twitter:description",
-        "content": python.frontmatter.description,
+        "content": python.metadata.description,
     } in meta
     assert {"name": "twitter:url", "content": url} in meta
 
     assert essays.permalink == "/en/category/essays"
-    assert "Essays" in essays.frontmatter.title
-    assert essays.frontmatter.description
-    assert essays.frontmatter.date is None
-    assert essays.frontmatter.category == category
-    assert essays.frontmatter.tags == []
+    assert "Essays" in essays.metadata.title
+    assert essays.metadata.description
+    assert essays.metadata.date is None
+    assert essays.metadata.category == category
+    assert essays.metadata.tags == []
 
-    meta = essays.meta
+    meta = build_meta_tags(essays)
     url = "https://florimond.dev/en/category/essays/"
     assert {"name": "twitter:card", "content": "summary_large_image"} in meta
-    assert {"name": "twitter:title", "content": essays.frontmatter.title} in meta
+    assert {"name": "twitter:title", "content": essays.metadata.title} in meta
     assert {
         "name": "twitter:description",
-        "content": essays.frontmatter.description,
+        "content": essays.metadata.description,
     } in meta
     assert {"name": "twitter:url", "content": url} in meta
 
@@ -161,7 +162,7 @@ def test_image_thumbnail(
     )
 
     (page,) = build_pages([item])
-    assert page.frontmatter.image_thumbnail == expected_image_thumbnail
+    assert page.metadata.image_thumbnail == expected_image_thumbnail
 
 
 @pytest.mark.parametrize(

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -20,11 +20,11 @@ async def test_images(client: httpx.AsyncClient) -> None:
 
     remote_urls = []
     for page in page_repository.find_all():
-        url = page.frontmatter.image
+        url = page.metadata.image
         if url is not None and url.startswith("http"):
             remote_urls.append(url)
 
-        url = page.frontmatter.image_thumbnail
+        url = page.metadata.image_thumbnail
         if url is not None and url.startswith("http"):
             remote_urls.append(url)
 


### PR DESCRIPTION
Follow-up to #340 

Metadata coming from a Markdown YAML frontmatter is an implementation detail. The `Frontmatter` entity was really a `Metadata` entity. HTML `<meta>` tag rendering has been moved to an `infrastructure/html.py` module.