### PR TITLE
Extract parser interface

### DIFF
--- a/server/domain/entities.py
+++ b/server/domain/entities.py
@@ -16,7 +16,7 @@ class Tag:
 
 @dataclasses.dataclass(frozen=True)
 class Metadata:
-    title: str
+    title: str = ""
     description: Optional[str] = None
     category: Optional[str] = None
     date: Optional[str] = None

--- a/server/domain/parsers.py
+++ b/server/domain/parsers.py
@@ -1,0 +1,6 @@
+from .entities import Metadata
+
+
+class Parser:
+    def parse(self, raw: str) -> tuple[str, Metadata]:
+        raise NotImplementedError  # pragma: no cover

--- a/server/infrastructure/adapters/markdown.py
+++ b/server/infrastructure/adapters/markdown.py
@@ -1,9 +1,0 @@
-import markdown as md
-
-from server import settings
-
-_impl = md.Markdown(extensions=settings.MARKDOWN_EXTENSIONS)
-
-
-def render(source: str) -> str:
-    return _impl.reset().convert(source)

--- a/server/infrastructure/database.py
+++ b/server/infrastructure/database.py
@@ -23,7 +23,7 @@ class PageDatabase:
             items, key=lambda item: item.location.parts[0]
         ):
             with using_locale(language):
-                pages = build_pages(list(language_items))
+                pages = await build_pages(list(language_items))
                 for page in pages:
                     assert page.language == language
                     self._store[page.language][page.permalink] = page

--- a/server/infrastructure/filesystem.py
+++ b/server/infrastructure/filesystem.py
@@ -1,40 +1,54 @@
 import glob
 from dataclasses import dataclass
 from pathlib import Path
+from typing import AsyncIterator
 
 import aiofiles
+from starlette.concurrency import run_in_threadpool
 
 from .. import settings
 
 
 @dataclass
 class ContentItem:
-    content: str
+    source: "ContentSource"
     location: Path
+
+
+class ContentSource:
+    async def get(self) -> str:
+        raise NotImplementedError  # pragma: no cover
+
+
+class FileContentSource(ContentSource):
+    def __init__(self, path: Path) -> None:
+        self._path = path
+
+    async def get(self) -> str:
+        async with aiofiles.open(self._path) as f:
+            return await f.read()
 
 
 async def load_content_items() -> list[ContentItem]:
     items = []
 
-    for root, path in iter_content_paths():
-        async with aiofiles.open(path) as f:
-            content = await f.read()
-            item = ContentItem(
-                content=content,
-                location=path.relative_to(root),
-            )
-            items.append(item)
+    async for root, path in aiter_content_paths():
+        item = ContentItem(
+            location=path.relative_to(root),
+            source=FileContentSource(path),
+        )
+        items.append(item)
 
     return items
 
 
-def iter_content_paths() -> list[tuple[Path, Path]]:
+async def aiter_content_paths() -> AsyncIterator[tuple[Path, Path]]:
     content_dirs = [settings.CONTENT_DIR, *settings.EXTRA_CONTENT_DIRS]
-    paths = []
 
     for root in content_dirs:
         pattern = str(root / "**" / "*.md")
-        for path in glob.glob(pattern, recursive=True):
-            paths.append((root, Path(path)))
-
-    return paths
+        globbed = await run_in_threadpool(
+            glob.glob, pattern, recursive=True  # type: ignore
+        )
+        for path in globbed:
+            yield (root, Path(str(path)))

--- a/server/infrastructure/pages.py
+++ b/server/infrastructure/pages.py
@@ -1,18 +1,16 @@
 from pathlib import Path
-from typing import Any, Iterable
-
-import frontmatter
+from typing import Iterable
 
 from .. import settings
 from ..domain.entities import Metadata, Page, Tag
 from ..i18n import get_locale
 from ..i18n import gettext_lazy as _
-from .adapters import markdown
 from .filesystem import ContentItem
+from .parsers import MarkdownParser
 
 
-def build_pages(items: list[ContentItem]) -> list[Page]:
-    pages = _build_content_pages(items)
+async def build_pages(items: list[ContentItem]) -> list[Page]:
+    pages = await _build_content_pages(items)
 
     tags = {tag for page in pages for tag in page.metadata.tags}
     pages.extend(_build_tag_pages(tags))
@@ -30,36 +28,21 @@ def build_pages(items: list[ContentItem]) -> list[Page]:
     return pages
 
 
-def _build_content_pages(items: list[ContentItem]) -> list[Page]:
+async def _build_content_pages(items: list[ContentItem]) -> list[Page]:
     pages = []
 
+    parser = MarkdownParser()
+
     for item in items:
-        post = frontmatter.loads(item.content)
-        content = post.content
-        attrs = dict(post)
+        content = await item.source.get()
+        html, metadata = parser.parse(content)
 
-        html = markdown.render(content)
         permalink = _build_permalink(item.location)
-        image, image_thumbnail = _process_image(attrs)
-
-        metadata = Metadata(
-            title=attrs["title"],
-            description=attrs.get("description"),
-            category=attrs.get("category"),
-            date=attrs.get("date"),
-            image=image,
-            image_thumbnail=image_thumbnail,
-            image_caption=attrs.get("image_caption"),
-            tags=[Tag(slug) for slug in attrs.get("tags", [])],
-        )
-
         page = Page(
             html=html,
-            content=content,
             permalink=permalink,
             metadata=metadata,
         )
-
         pages.append(page)
 
     return pages
@@ -106,38 +89,6 @@ def _build_permalink(location: Path) -> str:
     segments = location.with_suffix("").parts
     assert segments
     return "/" + "/".join(segments)
-
-
-def _process_image(attrs: dict[str, Any]) -> tuple[str | None, str | None]:
-    image = attrs.get("image")
-    image_thumbnail = attrs.get("image_thumbnail")
-
-    is_image_self_hosted = isinstance(image, str) and image.startswith(
-        settings.STATIC_ROOT
-    )
-
-    if image_thumbnail is None and is_image_self_hosted:
-        # By default, use the same image
-        image_thumbnail = image
-
-    if image_thumbnail == "__auto__":
-        # Convention: '/static/example.jpg' -> '/static/example_thumbnail.jpg'
-        if is_image_self_hosted:
-            assert isinstance(image, str)
-            image_thumbnail = _append_filename(image, "_thumbnail")
-        else:
-            image_thumbnail = None
-
-    assert image is None or isinstance(image, str)
-    assert image_thumbnail is None or isinstance(image_thumbnail, str)
-
-    return image, image_thumbnail
-
-
-def _append_filename(filename: str, suffix: str) -> str:
-    path = Path(filename)
-    name = f"{path.stem}{suffix}{path.suffix}"
-    return str(path.with_name(name))
 
 
 _CATEGORY_LABELS = {

--- a/server/infrastructure/parsers.py
+++ b/server/infrastructure/parsers.py
@@ -1,0 +1,65 @@
+from pathlib import Path
+from typing import Any
+
+import frontmatter
+import markdown as md
+
+from .. import settings
+from ..domain.entities import Metadata, Tag
+from ..domain.parsers import Parser
+
+
+class MarkdownParser(Parser):
+    def __init__(self) -> None:
+        self._impl = md.Markdown(extensions=settings.MARKDOWN_EXTENSIONS)
+
+    def parse(self, raw: str) -> tuple[str, Metadata]:
+        post = frontmatter.loads(raw)
+        content = self._impl.convert(post.content)
+        attrs = dict(post)
+        image, image_thumbnail = _process_image(attrs)
+
+        metadata = Metadata(
+            title=attrs.get("title", ""),
+            description=attrs.get("description"),
+            category=attrs.get("category"),
+            date=attrs.get("date"),
+            image=image,
+            image_thumbnail=image_thumbnail,
+            image_caption=attrs.get("image_caption"),
+            tags=[Tag(slug) for slug in attrs.get("tags", [])],
+        )
+
+        return content, metadata
+
+
+def _process_image(attrs: dict[str, Any]) -> tuple[str | None, str | None]:
+    image = attrs.get("image")
+    image_thumbnail = attrs.get("image_thumbnail")
+
+    is_image_self_hosted = isinstance(image, str) and image.startswith(
+        settings.STATIC_ROOT
+    )
+
+    if image_thumbnail is None and is_image_self_hosted:
+        # By default, use the same image
+        image_thumbnail = image
+
+    if image_thumbnail == "__auto__":
+        # Convention: '/static/example.jpg' -> '/static/example_thumbnail.jpg'
+        if is_image_self_hosted:
+            assert isinstance(image, str)
+            image_thumbnail = _append_filename(image, "_thumbnail")
+        else:
+            image_thumbnail = None
+
+    assert image is None or isinstance(image, str)
+    assert image_thumbnail is None or isinstance(image_thumbnail, str)
+
+    return image, image_thumbnail
+
+
+def _append_filename(filename: str, suffix: str) -> str:
+    path = Path(filename)
+    name = f"{path.stem}{suffix}{path.suffix}"
+    return str(path.with_name(name))

--- a/server/tools/mdformat.py
+++ b/server/tools/mdformat.py
@@ -4,6 +4,7 @@ Format ```python``` code blocks in Markdown source files:
 * Apply `black`.
 """
 import argparse
+import asyncio
 import io
 import sys
 import traceback
@@ -12,7 +13,7 @@ from pathlib import Path
 import black
 from pytest_codeblocks.main import extract_from_buffer
 
-from server.infrastructure.filesystem import iter_content_paths
+from server.infrastructure.filesystem import aiter_content_paths
 
 
 def _warn(text: str) -> str:
@@ -102,9 +103,9 @@ def _format_file(path: Path, *, check: bool) -> int:
     return 0
 
 
-def main(check: bool = False) -> int:
+async def main(check: bool = False) -> int:
     rv = 0
-    for _, path in iter_content_paths():
+    async for _, path in aiter_content_paths():
         rv |= _format_file(path, check=check)
     return rv
 
@@ -118,4 +119,4 @@ if __name__ == "__main__":  # pragma: no cover
         help="Fail if files would be reformatted.",
     )
     args = parser.parse_args()
-    sys.exit(main(check=args.check))
+    sys.exit(asyncio.run(main(check=args.check)))

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,8 +1,8 @@
-from server.infrastructure.adapters import markdown
+from server.infrastructure.parsers import MarkdownParser
 
 
 def test_image_figcaption() -> None:
-    content = markdown.render(
+    content, _ = MarkdownParser().parse(
         "![A beautiful mind](https://example.com/a-beautiful-mind)"
     )
 

--- a/tests/test_mdformat.py
+++ b/tests/test_mdformat.py
@@ -16,7 +16,8 @@ def tmp_content_dir(tmpdir: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return tmpdir
 
 
-def test_mdformat(tmp_content_dir: Path) -> None:
+@pytest.mark.asyncio
+async def test_mdformat(tmp_content_dir: Path) -> None:
     content_initial = dedent(
         """
         Before
@@ -43,11 +44,11 @@ def test_mdformat(tmp_content_dir: Path) -> None:
     testfile = tmp_content_dir / "test.md"
     testfile.write_text(content_initial, "utf-8")
 
-    rv = main(check=True)
+    rv = await main(check=True)
     assert rv == 1
     assert testfile.read_text("utf-8") == content_initial
 
-    rv = main()
+    rv = await main()
     assert rv == 0
     assert testfile.read_text("utf-8") == dedent(
         """
@@ -74,23 +75,25 @@ def test_mdformat(tmp_content_dir: Path) -> None:
         """
     )
 
-    rv = main(check=True)
+    rv = await main(check=True)
     assert rv == 0
 
 
-def test_mdformat_newlines(tmp_content_dir: Path) -> None:
+@pytest.mark.asyncio
+async def test_mdformat_newlines(tmp_content_dir: Path) -> None:
     content = "Final newline will be added."
     assert not content.endswith("\n")
 
     testfile = tmp_content_dir / "test.md"
     testfile.write_text(content, "utf-8")
 
-    rv = main()
+    rv = await main()
     assert rv == 0
     assert testfile.read_text("utf-8").endswith("\n")
 
 
-def test_mdformat_errors(tmp_content_dir: Path) -> None:
+@pytest.mark.asyncio
+async def test_mdformat_errors(tmp_content_dir: Path) -> None:
     invalid_python = dedent(
         """
     ```python
@@ -106,9 +109,9 @@ def test_mdformat_errors(tmp_content_dir: Path) -> None:
     testfile = tmp_content_dir / "test.md"
     testfile.write_text(invalid_python, "utf-8")
 
-    rv = main()
+    rv = await main()
     assert rv == 1
     assert testfile.read_text("utf-8") == invalid_python
 
-    rv = main(check=True)
+    rv = await main(check=True)
     assert rv == 1


### PR DESCRIPTION
Follow-up to #341 

Further abstract the markdown + YAML frontmatter implementation behind a `Parser` interface.