### PR TITLE
Ensure Letsencrypt cron job is setup

### DIFF
--- a/ansible/roles/www/tasks/main.yml
+++ b/ansible/roles/www/tasks/main.yml
@@ -41,3 +41,7 @@
     - name: Ensure app has letsencrypt
       dokku_letsencrypt:
         app: "{{ app }}"
+    
+    - name: Ensure LetsEncrypt auto-renew is enabled in Dokku
+      shell: dokku letsencrypt:cron-job --add
+      become: true


### PR DESCRIPTION
I received reminder emails from LetsEncrypt, which indicates enabling the `dokku_letsencrypt` plugin is not enough, and [Automatic certificate renewal](https://github.com/dokku/dokku-letsencrypt#automatic-certificate-renewal) has to be enabled.