### PR TITLE
Fix list of category posts

### DIFF
--- a/server/domain/repositories.py
+++ b/server/domain/repositories.py
@@ -11,7 +11,7 @@ class PageRepository:
         raise NotImplementedError  # pragma: no cover
 
     def find_all_post_pages(
-        self, *, tag__slug: str = None, category: str = None, limit: int = None
+        self, *, tag__slug: str = None, category: Category = None, limit: int = None
     ) -> list[Page]:
         raise NotImplementedError  # pragma: no cover
 

--- a/server/infrastructure/repositories.py
+++ b/server/infrastructure/repositories.py
@@ -24,7 +24,7 @@ class InMemoryPageRepository(PageRepository):
         self,
         *,
         tag__slug: str = None,
-        category: str = None,
+        category: Category = None,
         limit: int = None,
     ) -> list[Page]:
         posts: list[Page] = []
@@ -37,11 +37,7 @@ class InMemoryPageRepository(PageRepository):
             if tag__slug is not None:
                 if any(tag.slug == tag__slug for tag in page.metadata.tags):
                     continue
-            if (
-                category is not None
-                and (page_category := page.metadata.category) is not None
-                and page_category.name != category
-            ):
+            if category is not None and page.metadata.category != category:
                 continue
             posts.append(page)
 


### PR DESCRIPTION
Post-merge fix for #359 

Category pages such as https://florimond.dev/en/category/tutorials/ were not showing any pages anymore.

Aka the problems of no type checking in Jinja2 templates.

Also of not having any E2E tests.